### PR TITLE
use apiUrl instead of apiHost to align with FGA docs

### DIFF
--- a/examples/genkit/retrievers-with-fga/README.md
+++ b/examples/genkit/retrievers-with-fga/README.md
@@ -19,7 +19,7 @@ FGA_STORE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxx
 FGA_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxx
 FGA_CLIENT_SECRET=xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Optional
-FGA_API_HOST=api.xxx.fga.dev
+FGA_API_URL=https://api.xxx.fga.dev
 FGA_API_TOKEN_ISSUER=auth.fga.dev
 FGA_API_AUDIENCE=https://api.xxx.fga.dev/
 ```

--- a/examples/genkit/retrievers-with-fga/scripts/fga-init.ts
+++ b/examples/genkit/retrievers-with-fga/scripts/fga-init.ts
@@ -12,8 +12,7 @@ import { CredentialsMethod, OpenFgaClient } from "@openfga/sdk";
  */
 async function main() {
   const fgaClient = new OpenFgaClient({
-    apiScheme: "https",
-    apiHost: process.env.FGA_API_HOST || "api.us1.fga.dev",
+    apiUrl: process.env.FGA_API_URL || "https://api.us1.fga.dev",
     storeId: process.env.FGA_STORE_ID!,
     credentials: {
       method: CredentialsMethod.ClientCredentials,

--- a/examples/langchain/retrievers-with-fga/README.md
+++ b/examples/langchain/retrievers-with-fga/README.md
@@ -22,7 +22,7 @@ This example demonstrates how to combine [LangChain](https://js.langchain.com/do
     FGA_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxx
     FGA_CLIENT_SECRET=xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxx
     # Optional
-    FGA_API_HOST=api.xxx.fga.dev
+    FGA_API_URL=https://api.xxx.fga.dev
     FGA_API_TOKEN_ISSUER=auth.fga.dev
     FGA_API_AUDIENCE=https://api.xxx.fga.dev/
    ```

--- a/examples/langchain/retrievers-with-fga/scripts/fga-init.ts
+++ b/examples/langchain/retrievers-with-fga/scripts/fga-init.ts
@@ -12,8 +12,7 @@ import { CredentialsMethod, OpenFgaClient } from "@openfga/sdk";
  */
 async function main() {
   const fgaClient = new OpenFgaClient({
-    apiScheme: "https",
-    apiHost: process.env.FGA_API_HOST || "api.us1.fga.dev",
+    apiUrl: process.env.FGA_API_URL || "https://api.us1.fga.dev",
     storeId: process.env.FGA_STORE_ID!,
     credentials: {
       method: CredentialsMethod.ClientCredentials,

--- a/examples/llamaindex/retrievers-with-fga/README.md
+++ b/examples/llamaindex/retrievers-with-fga/README.md
@@ -22,7 +22,7 @@ This example demonstrates how to combine [LlamaIndex](https://ts.llamaindex.ai/)
     FGA_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxx
     FGA_CLIENT_SECRET=xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxx
     # Optional
-    FGA_API_HOST=api.xxx.fga.dev
+    FGA_API_URL=https://api.xxx.fga.dev
     FGA_API_TOKEN_ISSUER=auth.fga.dev
     FGA_API_AUDIENCE=https://api.xxx.fga.dev/
    ```

--- a/examples/llamaindex/retrievers-with-fga/scripts/fga-init.ts
+++ b/examples/llamaindex/retrievers-with-fga/scripts/fga-init.ts
@@ -12,8 +12,7 @@ import { CredentialsMethod, OpenFgaClient } from "@openfga/sdk";
  */
 async function main() {
   const fgaClient = new OpenFgaClient({
-    apiScheme: "https",
-    apiHost: process.env.FGA_API_HOST || "api.us1.fga.dev",
+    apiUrl: process.env.FGA_API_URL || "https://api.us1.fga.dev",
     storeId: process.env.FGA_STORE_ID!,
     credentials: {
       method: CredentialsMethod.ClientCredentials,

--- a/examples/openai-fga/README.md
+++ b/examples/openai-fga/README.md
@@ -20,7 +20,7 @@
    FGA_CLIENT_ID=
    FGA_CLIENT_SECRET=
    # Optional
-   FGA_API_HOST=api.xxx.fga.dev
+   FGA_API_URL=https://api.xxx.fga.dev
    FGA_API_TOKEN_ISSUER=auth.fga.dev
    FGA_API_AUDIENCE=https://api.xxx.fga.dev/
    ```

--- a/examples/openai-fga/scripts/fga-init.ts
+++ b/examples/openai-fga/scripts/fga-init.ts
@@ -12,8 +12,7 @@ import { CredentialsMethod, OpenFgaClient } from "@openfga/sdk";
  */
 async function main() {
   const fgaClient = new OpenFgaClient({
-    apiScheme: "https",
-    apiHost: process.env.FGA_API_HOST || "api.us1.fga.dev",
+    apiUrl: process.env.FGA_API_URL || "https://api.us1.fga.dev",
     storeId: process.env.FGA_STORE_ID!,
     credentials: {
       method: CredentialsMethod.ClientCredentials,
@@ -27,13 +26,9 @@ async function main() {
   });
 
   // 01. CONFIGURE PRE-DEFINED TUPLES
-  await fgaClient.write(
-    {
-      writes: [
-        { user: "user:*", relation: "viewer", object: "doc:public-doc" },
-      ],
-    }
-  );
+  await fgaClient.write({
+    writes: [{ user: "user:*", relation: "viewer", object: "doc:public-doc" }],
+  });
 }
 
 main().catch(console.error);

--- a/examples/openai-fga/src/fga-retriever.ts
+++ b/examples/openai-fga/src/fga-retriever.ts
@@ -32,8 +32,7 @@ export class FGARetriever {
     this.fgaClient =
       fgaClient ||
       new OpenFgaClient({
-        apiScheme: "https",
-        apiHost: process.env.FGA_API_HOST || "api.us1.fga.dev",
+        apiUrl: process.env.FGA_API_URL || "https://api.us1.fga.dev",
         storeId: process.env.FGA_STORE_ID!,
         credentials: {
           method: CredentialsMethod.ClientCredentials,

--- a/packages/ai-genkit/src/retrievers/fga-retriever.ts
+++ b/packages/ai-genkit/src/retrievers/fga-retriever.ts
@@ -47,8 +47,7 @@ export class FGARetriever {
     this.fgaClient =
       fgaClient ||
       new OpenFgaClient({
-        apiScheme: "https",
-        apiHost: process.env.FGA_API_HOST || "api.us1.fga.dev",
+        apiUrl: process.env.FGA_API_URL || "https://api.us1.fga.dev",
         storeId: process.env.FGA_STORE_ID!,
         credentials: {
           method: CredentialsMethod.ClientCredentials,

--- a/packages/ai-langchain/src/retrievers/fga-retriever.ts
+++ b/packages/ai-langchain/src/retrievers/fga-retriever.ts
@@ -51,8 +51,7 @@ export class FGARetriever<T extends ClientCheckRequest> extends BaseRetriever {
     const client =
       fgaClient ||
       new OpenFgaClient({
-        apiScheme: "https",
-        apiHost: process.env.FGA_API_HOST || "api.us1.fga.dev",
+        apiUrl: process.env.FGA_API_URL || "https://api.us1.fga.dev",
         storeId: process.env.FGA_STORE_ID!,
         credentials: {
           method: CredentialsMethod.ClientCredentials,

--- a/packages/ai-llamaindex/src/retrievers/fga-retriever.ts
+++ b/packages/ai-llamaindex/src/retrievers/fga-retriever.ts
@@ -57,8 +57,7 @@ export class FGARetriever extends BaseRetriever {
     this.fgaClient =
       fgaClient ||
       new OpenFgaClient({
-        apiScheme: "https",
-        apiHost: process.env.FGA_API_HOST || "api.us1.fga.dev",
+        apiUrl: process.env.FGA_API_URL || "https://api.us1.fga.dev",
         storeId: process.env.FGA_STORE_ID!,
         credentials: {
           method: CredentialsMethod.ClientCredentials,


### PR DESCRIPTION
When you create a new store in FGA, there is a modal that shows environment values to configure and so on. Here API_URL is shown instead of API_HOST and hence this change will make it less confusing to developers