### PR TITLE
fix fed connection demo

### DIFF
--- a/demos/vercel-ai/lib/auth0-ai.ts
+++ b/demos/vercel-ai/lib/auth0-ai.ts
@@ -5,11 +5,11 @@ import { auth0 } from "./auth0";
 const auth0AI = new Auth0AI();
 
 export const withCalendarFreeBusyAccess = auth0AI.withFederatedConnection({
-  getRefreshToken: async () => {
+  refreshToken: async () => {
     const session = await auth0.getSession();
     const refreshToken = session?.tokenSet.refreshToken! as string;
     return refreshToken;
   },
-  connection: 'google-oauth2',
+  connection: "google-oauth2",
   scopes: ["https://www.googleapis.com/auth/calendar.freebusy"],
 });

--- a/packages/ai-vercel/README.md
+++ b/packages/ai-vercel/README.md
@@ -39,7 +39,7 @@ import { auth0 } from "./auth0";
 
 export const withCalendarFreeBusyAccess = auth0AI.withFederatedConnection({
   // A function to retrieve the refresh token of the context.
-  getRefreshToken: async () => {
+  refreshToken: async () => {
     const session = await auth0.getSession();
     const refreshToken = session?.tokenSet.refreshToken!;
     return refreshToken;

--- a/packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts
+++ b/packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts
@@ -13,7 +13,7 @@ export class FederatedConnectionAuthorizer extends FederatedConnections.Federate
 > {
   protected override validateToken(tokenResponse: TokenResponse): void {
     try {
-      this.validateToken(tokenResponse);
+      super.validateToken(tokenResponse);
     } catch (err) {
       if (
         err instanceof Error &&


### PR DESCRIPTION
This pull request includes several changes to the `auth0` integration and the `FederatedConnectionAuthorizer` classes to improve functionality and error handling. The most important changes include renaming a method, modifying token validation, and handling optional token responses.

### Auth0 Integration Updates:
* [`demos/vercel-ai/lib/auth0-ai.ts`](diffhunk://#diff-2e7e5a7b4ebf321c1df40b2d152370ccf27b48863cafbc1a02a094f8adf104f9L8-R13): Renamed `getRefreshToken` method to `refreshToken` and adjusted the connection string format.
* [`packages/ai-vercel/README.md`](diffhunk://#diff-6c7b20f5b315d5227899a28d3b17d1fd20266b33e2bb028eb4be0708458a79aeL42-R42): Updated the method name from `getRefreshToken` to `refreshToken` in the documentation.

### Federated Connection Authorizer Updates:
* [`packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts`](diffhunk://#diff-169a9509c62b0bd0cca1cc8da22f9348a4a2a876fc2b341b381a1deb658e6c04L16-R16): Fixed token validation by calling `super.validateToken` instead of `this.validateToken`.
* [`packages/ai/src/authorizers/fedconn-authorizer.ts`](diffhunk://#diff-361b9fcb57815774667c569748313969b6ec0858972311752f91d41962f9a74dL54-R54): Modified `validateToken` to accept an optional `tokenResponse` parameter.
* [`packages/ai/src/authorizers/fedconn-authorizer.ts`](diffhunk://#diff-361b9fcb57815774667c569748313969b6ec0858972311752f91d41962f9a74dL85-R85): Updated `getAccessToken` to return `TokenResponse | undefined` and adjusted error handling to return instead of throwing an error. [[1]](diffhunk://#diff-361b9fcb57815774667c569748313969b6ec0858972311752f91d41962f9a74dL85-R85) [[2]](diffhunk://#diff-361b9fcb57815774667c569748313969b6ec0858972311752f91d41962f9a74dL108-L127)
* [`packages/ai/src/authorizers/fedconn-authorizer.ts`](diffhunk://#diff-361b9fcb57815774667c569748313969b6ec0858972311752f91d41962f9a74dL138-R124): Ensured `tokenResponse` is not undefined before accessing `access_token`.