### PR TITLE
refactor federated connection into namespace

### DIFF
--- a/packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts
+++ b/packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts
@@ -1,14 +1,14 @@
 import { Tool, ToolExecutionOptions } from "ai";
-import { TokenResponse } from "auth0/dist/cjs/auth/tokenExchange";
 import { Schema, z } from "zod";
 
-import { FederatedConnections } from "@auth0/ai";
+import { TokenResponse } from "@auth0/ai";
+import { FederatedConnectionAuthorizerBase } from "@auth0/ai/FederatedConnections";
 
 import { FederatedConnectionError } from "./FederatedConnectionError";
 
 type Parameters = z.ZodTypeAny | Schema<any>;
 
-export class FederatedConnectionAuthorizer extends FederatedConnections.FederatedConnectionAuthorizerBase<
+export class FederatedConnectionAuthorizer extends FederatedConnectionAuthorizerBase<
   [any, ToolExecutionOptions]
 > {
   protected override validateToken(tokenResponse: TokenResponse): void {

--- a/packages/ai-vercel/src/FederatedConnections/FederatedConnectionError.ts
+++ b/packages/ai-vercel/src/FederatedConnections/FederatedConnectionError.ts
@@ -1,8 +1,6 @@
-import { FederatedConnections } from "@auth0/ai";
+import { asyncLocalStorage } from "@auth0/ai/FederatedConnections";
 
 import { Interruption } from "#interruptions";
-
-const { asyncLocalStorage } = FederatedConnections;
 
 /**
  * Error thrown when a tool call requires an access token for an external service.

--- a/packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts
+++ b/packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts
@@ -1,6 +1,4 @@
-import { FederatedConnections } from "@auth0/ai";
-
-const { asyncLocalStorage } = FederatedConnections;
+import { asyncLocalStorage } from "@auth0/ai/FederatedConnections";
 
 export const getFederatedConnectionAccessToken = () => {
   const t = asyncLocalStorage.getStore();

--- a/packages/ai-vercel/tsconfig.json
+++ b/packages/ai-vercel/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,
     "isolatedModules": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "preserveWatchOutput": true,
@@ -21,7 +21,7 @@
       "dom",
       "ES2018"
     ],
-    "module": "ESNext",
+    "module": "NodeNext",
     "target": "ES2018",
     "outDir": "./dist",
     "baseUrl": ".",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -23,6 +23,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./FederatedConnections": {
+      "types": "./dist/authorizers/federated-connections/index.d.ts",
+      "import": "./dist/authorizers/federated-connections/index.mjs",
+      "require": "./dist/authorizers/federated-connections/index.js"
     }
   },
   "files": [

--- a/packages/ai/src/TokenResponse.ts
+++ b/packages/ai/src/TokenResponse.ts
@@ -1,0 +1,14 @@
+export type TokenResponse = {
+  /** Bearer token for API authorization */
+  access_token: string;
+  /** Refresh token (requires `offline_access` scope) */
+  refresh_token?: string;
+  /** JWT containing user identity claims */
+  id_token: string;
+  /** Typically "Bearer" */
+  token_type?: string;
+  /** Token validity in seconds (default: 86400) */
+  expires_in: number;
+  /** Granted permissions space */
+  scope: string;
+};

--- a/packages/ai/src/authorizers/federated-connections/asyncLocalStorage.ts
+++ b/packages/ai/src/authorizers/federated-connections/asyncLocalStorage.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type AsyncStorageValue<TContext> = {
+  getAccessToken: () => string;
+
+  /**
+   * The tool execution context.
+   */
+  context: TContext;
+
+  /**
+   * The federated connection name.
+   */
+  connection: string;
+
+  /**
+   * The scopes required to access the federated connection.
+   */
+  scopes: string[];
+
+  /**
+   * The scopes that the current access token has.
+   */
+  currentScopes?: string[];
+};
+
+export const asyncLocalStorage = new AsyncLocalStorage<
+  AsyncStorageValue<any>
+>();

--- a/packages/ai/src/authorizers/federated-connections/index.ts
+++ b/packages/ai/src/authorizers/federated-connections/index.ts
@@ -1,5 +1,9 @@
-import { TokenResponse } from "auth0/dist/cjs/auth/tokenExchange";
-import { AsyncLocalStorage } from "node:async_hooks";
+import { TokenResponse } from "../../TokenResponse";
+import { asyncLocalStorage } from "./asyncLocalStorage";
+
+export type { AsyncStorageValue } from "./asyncLocalStorage";
+
+export { asyncLocalStorage };
 
 export type FederatedConnectionAuthorizerParams<ToolExecuteArgs extends any[]> =
   {
@@ -7,34 +11,6 @@ export type FederatedConnectionAuthorizerParams<ToolExecuteArgs extends any[]> =
     scopes: string[];
     connection: string;
   };
-
-export type AsyncStorageValue<TContext> = {
-  getAccessToken: () => string;
-
-  /**
-   * The tool execution context.
-   */
-  context: TContext;
-
-  /**
-   * The federated connection name.
-   */
-  connection: string;
-
-  /**
-   * The scopes required to access the federated connection.
-   */
-  scopes: string[];
-
-  /**
-   * The scopes that the current access token has.
-   */
-  currentScopes?: string[];
-};
-
-export const asyncLocalStorage = new AsyncLocalStorage<
-  AsyncStorageValue<any>
->();
 
 /**
  * Requests authorization to a third party service via Federated Connection.

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,54 +1,7 @@
-import { AuthParams } from "./authorizers";
-
 export type { AuthParams, AuthorizerParams } from "./authorizers";
 export type * from "./credentials";
 export * from "./authorizers/ciba-authorizer";
 export * from "./authorizers/device-authorizer";
 export * from "./authorizers/fga-authorizer";
-export * as FederatedConnections from "./authorizers/fedconn-authorizer";
 export * from "./errors";
-
-export const usePipeline = <I, O>(
-  authorizers: any[],
-  handler: (authParams: AuthParams, input: I) => Promise<O>
-) => {
-  if (authorizers.length === 0) {
-    throw new Error("No authorizers provided");
-  }
-
-  if (authorizers.length > 2) {
-    throw new Error("Only 2 authorizers are allowed");
-  }
-
-  if (
-    authorizers[0].name !== "fga" &&
-    authorizers[1].name !== "fga" &&
-    authorizers[0].name !== "ciba" &&
-    authorizers[1].name !== "ciba"
-  ) {
-    throw new Error("FGA or CIBA must be one of the authorizers");
-  }
-
-  return async (input: I): Promise<O> => {
-    const fgaAuthorizer = authorizers.find((a) => a.name === "fga");
-    const cibaAuthorizer = authorizers.find((a) => a.name === "ciba");
-    const authorizer = authorizers.find(
-      (a) => a.name != "fga" && a.name != "ciba"
-    );
-    const authorizerHandler = (authParams: AuthParams) => authParams;
-    const authorizerResponse: AuthParams = await authorizer(authorizerHandler)(
-      input
-    );
-
-    const secondAuthorizer = cibaAuthorizer || fgaAuthorizer;
-
-    const response: AuthParams = await secondAuthorizer(authorizerHandler)({
-      ...input,
-      userId: authorizerResponse.claims?.sub,
-    });
-
-    const authParams = { ...authorizerResponse, ...response };
-
-    return handler(authParams, input);
-  };
-};
+export type { TokenResponse } from "./TokenResponse";

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig([
   {
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/authorizers/federated-connections/index.ts"],
     format: ["cjs", "esm"],
     dts: true,
     sourcemap: true,


### PR DESCRIPTION
This pull request includes several changes to the `ai-vercel` and `ai` packages, primarily focusing on refactoring imports, updating TypeScript configurations, and adding new type definitions. The most important changes are summarized below:

### Refactoring Imports:

* [`packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts`](diffhunk://#diff-169a9509c62b0bd0cca1cc8da22f9348a4a2a876fc2b341b381a1deb658e6c04L2-R11): Updated imports to use `@auth0/ai` and `@auth0/ai/FederatedConnections` instead of `auth0/dist/cjs/auth/tokenExchange` and `@auth0/ai`.
* [`packages/ai-vercel/src/FederatedConnections/FederatedConnectionError.ts`](diffhunk://#diff-2cb917cab113fea89ae4ebbe38b3f5a9cbdec08e4cb8ad79cde98eb8d094e15fL1-L6): Changed import to directly import `asyncLocalStorage` from `@auth0/ai/FederatedConnections`.
* [`packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts`](diffhunk://#diff-9ba234cadbc52942b8488636caf5ab40e505f907932b0ffdbd80de1978a9e26cL1-R1): Updated import to directly import `asyncLocalStorage` from `@auth0/ai/FederatedConnections`.

### TypeScript Configuration Updates:

* [`packages/ai-vercel/tsconfig.json`](diffhunk://#diff-545bb25cc459f5e6532e27d9d3deb9de82b028cef269bb23033e19bf02e76616L10-R10): Changed `moduleResolution` to `nodenext` and `module` to `NodeNext` [[1]](diffhunk://#diff-545bb25cc459f5e6532e27d9d3deb9de82b028cef269bb23033e19bf02e76616L10-R10) [[2]](diffhunk://#diff-545bb25cc459f5e6532e27d9d3deb9de82b028cef269bb23033e19bf02e76616L24-R24).

### Adding New Type Definitions:

* [`packages/ai/src/TokenResponse.ts`](diffhunk://#diff-ecb8db1c4074e2f2091244de8ca32d5bb625d4674394b5fe53aa424e29efd1f5R1-R14): Added a new type definition for `TokenResponse`.
* [`packages/ai/src/authorizers/federated-connections/asyncLocalStorage.ts`](diffhunk://#diff-62f12e044ac6e60758f0c39f4b809e9d33994d0ff1ebe6e4b162d9c41a5ed3f4R1-R29): Added new type `AsyncStorageValue` and initialized `asyncLocalStorage` with `AsyncLocalStorage` from `node:async_hooks`.

### Package Configuration:

* [`packages/ai/package.json`](diffhunk://#diff-3758ea4fd63e4789bf712baab7b4b0227fce843a17e2ed535091b9c3b83ff2dfR26-R30): Added new export paths for `FederatedConnections`.
* [`packages/ai/tsup.config.ts`](diffhunk://#diff-32e50584d3c65671eba90438af4aa48d47668ea14c93fec076fc532e45440b58L5-R5): Included `src/authorizers/federated-connections/index.ts` in the entry points for the build configuration.