### PR TITLE
chore: add tests for CIBA in ai-vercel

### DIFF
--- a/packages/ai-vercel/package.json
+++ b/packages/ai-vercel/package.json
@@ -14,7 +14,7 @@
     "clean": "rm -rf dist",
     "lint": "eslint \"./**/*.ts*\"",
     "type-check": "tsc --noEmit",
-    "test": "echo 'missing tests'"
+    "test": "vitest run"
   },
   "imports": {
     "#interruptions": {

--- a/packages/ai-vercel/src/CIBA/CIBAuthorizationError.ts
+++ b/packages/ai-vercel/src/CIBA/CIBAuthorizationError.ts
@@ -1,4 +1,4 @@
-import { asyncLocalStorage } from "@auth0/ai/FederatedConnections";
+import { asyncLocalStorage } from "@auth0/ai/CIBA";
 
 import { Interruption } from "#interruptions";
 

--- a/packages/ai-vercel/test/CIBAAuthorizer.test.ts
+++ b/packages/ai-vercel/test/CIBAAuthorizer.test.ts
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { Tool, ToolExecutionOptions } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  AuthorizationPending,
+  AuthorizationRequestExpiredError,
+} from "@auth0/ai";
+import { CIBAAuthorizerBase } from "@auth0/ai/CIBA";
+
+import { CIBAuthorizationError } from "../src/CIBA";
+import { CIBAAuthorizer } from "../src/CIBA/CIBAAuthorizer";
+
+describe("CIBAAuthorizer", () => {
+  let authorizer: CIBAAuthorizer;
+  let mockTool: Tool;
+  let protectedTool: Tool;
+  const authorizerParameters = {
+    userID: (params: { userID: string }) => params.userID,
+    bindingMessage: "Confirm the purchase",
+    scope: "openid stock:trade",
+    audience: "http://localhost:8081",
+    getAuthorizationResponse: vi.fn(),
+    storeAuthorizationResponse: vi.fn(),
+  };
+
+  beforeEach(() => {
+    authorizer = new CIBAAuthorizer(
+      {
+        clientId: "client-id",
+        clientSecret: "client",
+        domain: "test",
+      },
+      authorizerParameters
+    );
+
+    mockTool = {
+      description: "A mock tool for testing",
+      parameters: z.object({
+        userID: z.string(),
+        input: z.string(),
+      }),
+      execute: vi.fn().mockResolvedValue({ result: "success" }),
+    };
+
+    protectedTool = authorizer.authorizer()(mockTool);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("on authorization pending error", () => {
+    let error: CIBAuthorizationError;
+    beforeEach(async () => {
+      authorizerParameters.getAuthorizationResponse.mockResolvedValue({
+        status: "pending",
+      });
+
+      vi.spyOn(
+        CIBAAuthorizerBase.prototype,
+        //@ts-ignore
+        "getCredentials"
+      ).mockImplementation(() => {
+        throw new AuthorizationPending("Authorization pending");
+      });
+
+      try {
+        await protectedTool!.execute!(
+          { userID: "user1", input: "input" },
+          {} as ToolExecutionOptions
+        );
+      } catch (err) {
+        error = err as CIBAuthorizationError;
+      }
+    });
+
+    it("should throw a final error", () => {
+      expect(error).toBeInstanceOf(CIBAuthorizationError);
+      expect(error.isFinal).toBe(false);
+    });
+
+    it("should not call the tool execute method", () => {
+      expect(mockTool.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("on authorization request expired error", () => {
+    let error: CIBAuthorizationError;
+    beforeEach(async () => {
+      authorizerParameters.getAuthorizationResponse.mockResolvedValue({
+        status: "pending",
+      });
+
+      vi.spyOn(
+        CIBAAuthorizerBase.prototype,
+        //@ts-ignore
+        "getCredentials"
+      ).mockImplementation(() => {
+        throw new AuthorizationRequestExpiredError("Authorization pending");
+      });
+
+      try {
+        await protectedTool!.execute!(
+          { userID: "user1", input: "input" },
+          {} as ToolExecutionOptions
+        );
+      } catch (err) {
+        error = err as CIBAuthorizationError;
+      }
+    });
+
+    it("should throw a non final error", () => {
+      expect(error).toBeInstanceOf(CIBAuthorizationError);
+      expect(error.isFinal).toBe(true);
+    });
+
+    it("should not call the tool execute method", () => {
+      expect(mockTool.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("on completed authorization request", () => {
+    let error: CIBAuthorizationError;
+    beforeEach(async () => {
+      authorizerParameters.getAuthorizationResponse.mockResolvedValue({
+        status: "pending",
+      });
+
+      vi.spyOn(
+        CIBAAuthorizerBase.prototype,
+        //@ts-ignore
+        "getCredentials"
+        //@ts-ignore
+      ).mockImplementation(() => {
+        return {
+          accessToken: {
+            type: "bearer",
+            value: "foobr",
+          },
+        };
+      });
+
+      try {
+        await protectedTool!.execute!(
+          { userID: "user1", input: "input" },
+          {} as ToolExecutionOptions
+        );
+      } catch (err) {
+        error = err as CIBAuthorizationError;
+      }
+    });
+
+    it("should not throw an error", () => {
+      expect(error).toBeUndefined();
+    });
+
+    it("should call the tool execute method", () => {
+      expect(mockTool.execute).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/ai/src/authorizers/ciba/index.ts
+++ b/packages/ai/src/authorizers/ciba/index.ts
@@ -270,10 +270,8 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
           ...args
         );
       }
-      const credentials = await this.getCredentials(authorizeResponse);
 
       const storeValue: AsyncStorageValue<any> = {
-        credentials,
         context: getContext(...args),
       };
 
@@ -284,6 +282,8 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
       }
 
       return asyncLocalStorage.run(storeValue, async () => {
+        const credentials = await this.getCredentials(authorizeResponse);
+        storeValue.credentials = credentials;
         return execute(...args);
       });
     };


### PR DESCRIPTION
This pull request includes several significant changes to the `ai-vercel` package, focusing on updating dependencies, improving error handling, and adding comprehensive tests for the `CIBAAuthorizer` class. Below are the most important changes:

### Dependency Updates:
* Updated the `test` script in `package.json` to use `vitest` instead of a placeholder. (`packages/ai-vercel/package.json`, [packages/ai-vercel/package.jsonL17-R17](diffhunk://#diff-58aa606e03887c81c436e799d7cb8d4a0c422a590d7222c9905188dde4cd5afcL17-R17))

### Code Improvements:
* Changed the import path for `asyncLocalStorage` in `CIBAuthorizationError.ts` to use the `CIBA` module instead of `FederatedConnections`. (`packages/ai-vercel/src/CIBA/CIBAuthorizationError.ts`, [packages/ai-vercel/src/CIBA/CIBAuthorizationError.tsL1-R1](diffhunk://#diff-76459a82cd60a65faef838748903f48595c2ea98c77600d6bef5018eb5bbfb72L1-R1))

### Testing Enhancements:
* Added a comprehensive test suite for the `CIBAAuthorizer` class, covering various authorization scenarios, including pending authorization, expired authorization, and completed authorization requests. (`packages/ai-vercel/test/CIBAAuthorizer.test.ts`, [packages/ai-vercel/test/CIBAAuthorizer.test.tsR1-R163](diffhunk://#diff-29d34b5a6190a185530a9a27779db6e24f98d287065398a066c820634721582bR1-R163))

### Code Refactoring:
* Moved the `getCredentials` call within the `asyncLocalStorage.run` method to ensure credentials are fetched and stored correctly during the execution of the tool. (`packages/ai/src/authorizers/ciba/index.ts`, [[1]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL273-L276) [[2]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfR285-R286)