### PR TITLE
refactor federated connections and add tests

### DIFF
--- a/packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts
+++ b/packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts
@@ -7,5 +7,5 @@ export const getFederatedConnectionAccessToken = () => {
       "The tool must be wrapped with the withThirdPartyAPIAccess function."
     );
   }
-  return t.getAccessToken();
+  return t.accessToken;
 };

--- a/packages/ai/src/authorizers/ciba/index.ts
+++ b/packages/ai/src/authorizers/ciba/index.ts
@@ -63,27 +63,11 @@ export type CIBAAuthorizerParams<ToolExecuteArgs extends any[]> = {
   ) => Promise<void>;
 };
 
-export enum CibaAuthorizerCheckResponse {
-  PENDING = "pending",
-  APPROVED = "approved",
-  REJECTED = "rejected",
-  EXPIRED = "expired",
-}
-
 export type AuthorizeResponse = {
   authReqId: string;
   requestedAt: number;
   expiresIn: number;
   interval: number;
-};
-
-export type TokenResponse = {
-  accessToken: string;
-  refreshToken?: string;
-  idToken: string;
-  tokenType?: string;
-  expiresIn: number;
-  scope: string;
 };
 
 function ensureOpenIdScope(scope: string): string {

--- a/packages/ai/src/authorizers/federated-connections/asyncLocalStorage.ts
+++ b/packages/ai/src/authorizers/federated-connections/asyncLocalStorage.ts
@@ -1,7 +1,10 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 export type AsyncStorageValue<TContext> = {
-  getAccessToken: () => string;
+  /**
+   * The Federated Connection access token.
+   */
+  accessToken?: string;
 
   /**
    * The tool execution context.

--- a/packages/ai/test/federated-connection-base.test.ts
+++ b/packages/ai/test/federated-connection-base.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  asyncLocalStorage,
+  FederatedConnectionAuthorizerBase,
+} from "../src/authorizers/federated-connections";
+
+class FedConnMockImpl extends FederatedConnectionAuthorizerBase<[string]> {
+  public protect(
+    getContext: (args_0: string) => any,
+    execute: (args_0: string) => any
+  ): (args_0: string) => any {
+    return super.protect(getContext, execute);
+  }
+}
+
+const fetchMock = vi.fn();
+
+vi.stubGlobal("fetch", fetchMock);
+
+describe("FederatedConnectionAuthorizerBase", () => {
+  let authorizer: FedConnMockImpl;
+  const mockParams = {
+    connection: "test-connection",
+    scopes: ["read:calendar"],
+    refreshToken: vi.fn(),
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    authorizer = new FedConnMockImpl(
+      {
+        domain: "test.auth0.com",
+        clientId: "test-client",
+        clientSecret: "test-secret",
+      },
+      mockParams
+    );
+  });
+
+  describe("constructor", () => {
+    it("should initialize with explicit params", () => {
+      const auth = new FedConnMockImpl(
+        {
+          domain: "custom.auth0.com",
+          clientId: "custom-client",
+          clientSecret: "custom-secret",
+        },
+        mockParams
+      );
+      expect(auth).toBeInstanceOf(FedConnMockImpl);
+    });
+  });
+
+  /**
+   * If the refresh token can't be exchanged for an access token,
+   * the authorizer should throw an error.
+   *
+   */
+  describe("on exchange failure", () => {
+    const execute = vi.fn();
+    let err: Error;
+    beforeEach(async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: async () => ({ error: "Unauthorized" }),
+      });
+
+      try {
+        await authorizer.protect(() => {}, execute)("test-context");
+      } catch (er) {
+        err = er as Error;
+      }
+    });
+
+    it('should throw "Authorization required" error', async () => {
+      expect(err.message).toMatch(
+        /Authorization required to access the Federated Connection/gi
+      );
+    });
+
+    it("should not call the protected execute method", async () => {
+      expect(execute).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * When the refresh token is exchanged for an access token with insufficient scopes
+   * the authorizer should throw an error.
+   */
+  describe("on insufficient scopes", () => {
+    const execute = vi.fn();
+    let err: Error;
+    beforeEach(async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          scope: "read:profile read:foobar",
+          access_token: "test",
+        }),
+      });
+
+      try {
+        await authorizer.protect(() => {}, execute)("test-context");
+      } catch (er) {
+        err = er as Error;
+      }
+    });
+
+    it('should throw "Authorization required" error', async () => {
+      expect(err.message).toMatchInlineSnapshot(
+        `"Authorization required to access the Federated Connection: test-connection. Missing scopes: read:calendar"`
+      );
+    });
+
+    it("should not call the protected execute method", async () => {
+      expect(execute).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * When the refresh token is exchanged for an access token with proper scopes
+   * the authorizer should not throw an error and call the underlying execute method.
+   */
+  describe("on succesful exchange", () => {
+    const execute = vi.fn();
+    let err: Error;
+    let accessTokenFromAsyncLocalStore: string | undefined;
+
+    beforeEach(async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          scope: "read:profile read:calendar",
+          access_token: "test",
+        }),
+      });
+      execute.mockImplementation(() => {
+        const store = asyncLocalStorage.getStore();
+        accessTokenFromAsyncLocalStore = store?.accessToken;
+      });
+      try {
+        await authorizer.protect(() => {}, execute)("test-context");
+      } catch (er) {
+        err = er as Error;
+      }
+    });
+
+    it("should not throw error", async () => {
+      expect(err).toBeUndefined();
+    });
+
+    it("should not call the protected execute method", async () => {
+      expect(execute).toHaveBeenCalled();
+    });
+
+    it("should store the access token in the async local storage", async () => {
+      expect(accessTokenFromAsyncLocalStore).toBe("test");
+    });
+
+    it("should exchange the token properly", async () => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://test.auth0.com/oauth/token",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+          }),
+          body: expect.any(String),
+        })
+      );
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(body).toMatchInlineSnapshot(`
+        {
+          "client_id": "test-client",
+          "client_secret": "test-secret",
+          "connection": "test-connection",
+          "grant_type": "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token",
+          "requested_token_type": "http://auth0.com/oauth/token-type/federated-connection-access-token",
+          "subject_token_type": "urn:ietf:params:oauth:token-type:refresh_token",
+        }
+      `);
+    });
+  });
+});


### PR DESCRIPTION
This pull request includes several changes to the federated connections authorization process, focusing on simplifying the access token handling and improving the test coverage. The most important changes include replacing the `getAccessToken` method with the `accessToken` property, updating the `FederatedConnectionAuthorizerBase` class to use the new property, and adding comprehensive tests for the authorization process.

### Simplification of Access Token Handling:

* [`packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts`](diffhunk://#diff-9ba234cadbc52942b8488636caf5ab40e505f907932b0ffdbd80de1978a9e26cL10-R10): Replaced the `getAccessToken` method with the `accessToken` property.
* [`packages/ai/src/authorizers/federated-connections/asyncLocalStorage.ts`](diffhunk://#diff-62f12e044ac6e60758f0c39f4b809e9d33994d0ff1ebe6e4b162d9c41a5ed3f4L4-R7): Updated the `AsyncStorageValue` type to include the `accessToken` property instead of the `getAccessToken` method.
* [`packages/ai/src/authorizers/federated-connections/index.ts`](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L104-R105): Modified the `FederatedConnectionAuthorizerBase` class to use the `accessToken` property in the async local storage. [[1]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L104-R105) [[2]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L122-R120)

### Removal of Redundant Code:

* [`packages/ai/src/authorizers/ciba/index.ts`](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL66-L88): Removed the `CibaAuthorizerCheckResponse` enum and `TokenResponse` type as they are no longer needed.

### Test Coverage Improvements:

* [`packages/ai/test/federated-connection-base.test.ts`](diffhunk://#diff-b0b5fcd45b46920ce9e9cfed1ec0c18245053e9842542ea2683f12a3860594d8R1-R192): Added comprehensive tests for the `FederatedConnectionAuthorizerBase` class, covering scenarios such as token exchange failures, insufficient scopes, and successful exchanges.