### PR TITLE
chore: refactor federated connections

### DIFF
--- a/packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts
+++ b/packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts
@@ -1,7 +1,7 @@
 import { Tool, ToolExecutionOptions } from "ai";
 import { Schema, z } from "zod";
 
-import { TokenResponse } from "@auth0/ai";
+import { AuthorizationRequired } from "@auth0/ai";
 import { FederatedConnectionAuthorizerBase } from "@auth0/ai/FederatedConnections";
 
 import { FederatedConnectionError } from "./FederatedConnectionError";
@@ -11,18 +11,10 @@ type Parameters = z.ZodTypeAny | Schema<any>;
 export class FederatedConnectionAuthorizer extends FederatedConnectionAuthorizerBase<
   [any, ToolExecutionOptions]
 > {
-  protected override validateToken(tokenResponse: TokenResponse): void {
-    try {
-      super.validateToken(tokenResponse);
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        err.message.startsWith("Authorization required")
-      ) {
-        throw new FederatedConnectionError(err.message);
-      }
-      throw err;
-    }
+  protected override handleAuthorizationErrors(
+    err: AuthorizationRequired
+  ): void {
+    throw new FederatedConnectionError(err.message);
   }
 
   authorizer() {

--- a/packages/ai-vercel/test/FerderatedConnectionAuthorizer.test.ts
+++ b/packages/ai-vercel/test/FerderatedConnectionAuthorizer.test.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { Tool, ToolExecutionOptions } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { AuthorizationRequired } from "@auth0/ai";
+import { FederatedConnectionAuthorizerBase } from "@auth0/ai/FederatedConnections";
+
+import {
+  FederatedConnectionAuthorizer,
+  FederatedConnectionError,
+  getFederatedConnectionAccessToken,
+} from "../src/FederatedConnections";
+
+describe("FederatedConnectionAuthorizer", () => {
+  const mockTool = {
+    description: "A mock tool for testing",
+    parameters: z.object({
+      userID: z.string(),
+      input: z.string(),
+    }),
+    execute: vi.fn().mockResolvedValue({ result: "success" }),
+  };
+  const authorizerParameters = {
+    connection: "test-connection",
+    scopes: ["test-scope"],
+    refreshToken: vi.fn(),
+  };
+  let authorizer: FederatedConnectionAuthorizer;
+  let protectedTool: Tool;
+
+  beforeEach(() => {
+    authorizer = new FederatedConnectionAuthorizer(
+      {
+        clientId: "client-id",
+        clientSecret: "client",
+        domain: "test",
+      },
+      authorizerParameters
+    );
+
+    protectedTool = authorizer.authorizer()(mockTool);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("on authorization error", () => {
+    let error: FederatedConnectionError;
+    beforeEach(async () => {
+      vi.spyOn(
+        FederatedConnectionAuthorizerBase.prototype,
+        //@ts-ignore
+        "getAccessToken"
+      ).mockImplementation(() => {
+        throw new AuthorizationRequired("Authorization required");
+      });
+
+      try {
+        await protectedTool!.execute!(
+          { userID: "user1", input: "input" },
+          {} as ToolExecutionOptions
+        );
+      } catch (err) {
+        error = err as FederatedConnectionError;
+      }
+    });
+
+    it("should throw a federated connection error", () => {
+      expect(error).toBeInstanceOf(FederatedConnectionError);
+    });
+
+    it("should not call the tool execute", () => {
+      expect(mockTool.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("on authorization success", () => {
+    let error: FederatedConnectionError;
+    let accessToken: string | undefined;
+
+    beforeEach(async () => {
+      vi.spyOn(
+        FederatedConnectionAuthorizerBase.prototype,
+        //@ts-ignore
+        "getAccessToken"
+        //@ts-ignore
+      ).mockImplementation(() => {
+        return {
+          access_token: "access_token",
+          scope: "test-scope",
+        };
+      });
+
+      try {
+        mockTool.execute.mockImplementation(() => {
+          accessToken = getFederatedConnectionAccessToken();
+          return { result: "success" };
+        });
+        await protectedTool!.execute!(
+          { userID: "user1", input: "input" },
+          {} as ToolExecutionOptions
+        );
+      } catch (err) {
+        error = err as FederatedConnectionError;
+      }
+    });
+
+    it("should not throw any error", () => {
+      expect(error).toBeUndefined();
+    });
+
+    it("should call the tool execute", () => {
+      expect(mockTool.execute).toHaveBeenCalled();
+    });
+
+    it("should be able to retrieve the token from within the tool", () => {
+      expect(accessToken).toBe("access_token");
+    });
+  });
+});

--- a/packages/ai/src/authorizers/ciba/index.ts
+++ b/packages/ai/src/authorizers/ciba/index.ts
@@ -177,57 +177,6 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
     }
   }
 
-  // private async poll(params: AuthorizeResponse): Promise<Credentials> {
-  //   return new Promise((resolve, reject) => {
-  //     const startTime = Date.now();
-  //     const interval = setInterval(async () => {
-  //       try {
-  //         const elapsedSeconds = (Date.now() - startTime) / 1000;
-
-  //         if (elapsedSeconds >= params.expiresIn) {
-  //           clearInterval(interval);
-  //           return reject(
-  //             new AuthorizationRequestExpiredError(
-  //               "Authorization request has expired"
-  //             )
-  //           );
-  //         }
-
-  //         const response = await this.auth0.backchannel.backchannelGrant({
-  //           auth_req_id: params.authReqId,
-  //         });
-
-  //         const credentials = {
-  //           accessToken: {
-  //             type: response.token_type || "bearer",
-  //             value: response.access_token,
-  //           },
-  //         };
-
-  //         clearInterval(interval);
-
-  //         return resolve(credentials);
-  //       } catch (e: any) {
-  //         if (e.error == "invalid_request") {
-  //           clearInterval(interval);
-  //           return reject(
-  //             new UserDoesNotHavePushNotificationsError(e.error_description)
-  //           );
-  //         }
-
-  //         if (e.error == "access_denied") {
-  //           clearInterval(interval);
-  //           return reject(new AccessDeniedError(e.error_description));
-  //         }
-
-  //         if (e.error == "authorization_pending") {
-  //           return;
-  //         }
-  //       }
-  //     }, params.interval * 1000);
-  //   });
-  // }
-
   /**
    *
    * Wraps the execute method of a AI tool to handle CIBA authorization.
@@ -236,7 +185,7 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
    * @param execute - The tool execute method.
    * @returns The wrapped execute method.
    */
-  protected protect(
+  protect(
     getContext: (...args: ToolExecuteArgs) => any,
     execute: (...args: ToolExecuteArgs) => any
   ): (...args: ToolExecuteArgs) => any {

--- a/packages/ai/src/errors.ts
+++ b/packages/ai/src/errors.ts
@@ -25,3 +25,10 @@ export class AuthorizationPending extends Error {
     this.name = AuthorizationPending.name;
   }
 }
+
+export class AuthorizationRequired extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = AuthorizationRequired.name;
+  }
+}

--- a/packages/ai/test/ciba-authorizer-base.test.ts
+++ b/packages/ai/test/ciba-authorizer-base.test.ts
@@ -8,18 +8,10 @@ import {
   AuthorizationRequestExpiredError,
 } from "../src/errors";
 
-class CIBAAuthorizerMockImpl extends CIBAAuthorizerBase<[string]> {
-  public protect(
-    getContext: (args_0: string) => any,
-    execute: (args_0: string) => any
-  ): (args_0: string) => any {
-    return super.protect(getContext, execute);
-  }
-}
 vi.mock("auth0");
 
 describe("CIBAAuthorizerBase", () => {
-  let authorizer: CIBAAuthorizerMockImpl;
+  let authorizer: CIBAAuthorizerBase<[string]>;
   const mockParams = {
     userID: "user123",
     bindingMessage: "test-binding",
@@ -44,7 +36,7 @@ describe("CIBAAuthorizerBase", () => {
   });
 
   beforeEach(() => {
-    authorizer = new CIBAAuthorizerMockImpl(
+    authorizer = new CIBAAuthorizerBase(
       {
         domain: "test.auth0.com",
         clientId: "test-client",
@@ -56,7 +48,7 @@ describe("CIBAAuthorizerBase", () => {
 
   describe("constructor", () => {
     it("should initialize with explicit params", () => {
-      const auth = new CIBAAuthorizerMockImpl(
+      const auth = new CIBAAuthorizerBase(
         {
           domain: "custom.auth0.com",
           clientId: "custom-client",
@@ -64,7 +56,7 @@ describe("CIBAAuthorizerBase", () => {
         },
         mockParams
       );
-      expect(auth).toBeInstanceOf(CIBAAuthorizerMockImpl);
+      expect(auth).toBeInstanceOf(CIBAAuthorizerBase);
     });
 
     it("should fallback to environment variables", () => {
@@ -72,7 +64,7 @@ describe("CIBAAuthorizerBase", () => {
       process.env.AUTH0_CLIENT_ID = "env-client";
       process.env.AUTH0_CLIENT_SECRET = "env-secret";
 
-      const auth = new CIBAAuthorizerMockImpl({}, mockParams);
+      const auth = new CIBAAuthorizerBase({}, mockParams);
       expect(auth).toBeInstanceOf(CIBAAuthorizerBase);
     });
   });

--- a/packages/ai/test/federated-connection-base.test.ts
+++ b/packages/ai/test/federated-connection-base.test.ts
@@ -5,25 +5,16 @@ import {
   FederatedConnectionAuthorizerBase,
 } from "../src/authorizers/federated-connections";
 
-class FedConnMockImpl extends FederatedConnectionAuthorizerBase<[string]> {
-  public protect(
-    getContext: (args_0: string) => any,
-    execute: (args_0: string) => any
-  ): (args_0: string) => any {
-    return super.protect(getContext, execute);
-  }
-}
-
 const fetchMock = vi.fn();
 
 vi.stubGlobal("fetch", fetchMock);
 
 describe("FederatedConnectionAuthorizerBase", () => {
-  let authorizer: FedConnMockImpl;
+  let authorizer: FederatedConnectionAuthorizerBase<[string]>;
   const mockParams = {
     connection: "test-connection",
     scopes: ["read:calendar"],
-    refreshToken: vi.fn(),
+    refreshToken: vi.fn().mockResolvedValue("test-refresh-token"),
   };
 
   afterEach(() => {
@@ -31,7 +22,7 @@ describe("FederatedConnectionAuthorizerBase", () => {
   });
 
   beforeEach(() => {
-    authorizer = new FedConnMockImpl(
+    authorizer = new FederatedConnectionAuthorizerBase<[string]>(
       {
         domain: "test.auth0.com",
         clientId: "test-client",
@@ -43,7 +34,7 @@ describe("FederatedConnectionAuthorizerBase", () => {
 
   describe("constructor", () => {
     it("should initialize with explicit params", () => {
-      const auth = new FedConnMockImpl(
+      const auth = new FederatedConnectionAuthorizerBase<[string]>(
         {
           domain: "custom.auth0.com",
           clientId: "custom-client",
@@ -51,7 +42,7 @@ describe("FederatedConnectionAuthorizerBase", () => {
         },
         mockParams
       );
-      expect(auth).toBeInstanceOf(FedConnMockImpl);
+      expect(auth).toBeInstanceOf(FederatedConnectionAuthorizerBase<[string]>);
     });
   });
 
@@ -184,6 +175,7 @@ describe("FederatedConnectionAuthorizerBase", () => {
           "connection": "test-connection",
           "grant_type": "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token",
           "requested_token_type": "http://auth0.com/oauth/token-type/federated-connection-access-token",
+          "subject_token": "test-refresh-token",
           "subject_token_type": "urn:ietf:params:oauth:token-type:refresh_token",
         }
       `);


### PR DESCRIPTION
This pull request includes significant changes to the Federated Connection and CIBA authorizers in the `ai-vercel` package, focusing on error handling and test improvements. The most important changes are the introduction of a new `AuthorizationRequired` error, updates to error handling in the Federated Connection authorizer, and the removal of unnecessary code in the CIBA authorizer.

Error Handling Enhancements:

* updated the error handling method to throw a `FederatedConnectionError` when authorization is required. [[1]](diffhunk://#diff-169a9509c62b0bd0cca1cc8da22f9348a4a2a876fc2b341b381a1deb658e6c04L4-R4) [[2]](diffhunk://#diff-169a9509c62b0bd0cca1cc8da22f9348a4a2a876fc2b341b381a1deb658e6c04L14-L26)
* [`packages/ai/src/authorizers/federated-connections/index.ts`](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7R1-R2): Added `AuthorizationRequired` error handling and updated the `validateToken` and `getAccessToken` methods to throw `AuthorizationRequired` when necessary. [[1]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7R1-R2) [[2]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L20-R22) [[3]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7R32-R35) [[4]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L41-R45) [[5]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L53-R57) [[6]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7R68-R83) [[7]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L100-R110) [[8]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7R128-R138)
* [`packages/ai/src/errors.ts`](diffhunk://#diff-8d963572667c5e454e1d83c6cce3024d8c316950c1f6907fcbf3c10d33adac68R28-R34): Introduced the new `AuthorizationRequired` error class.

Test Improvements:

* [`packages/ai-vercel/test/FerderatedConnectionAuthorizer.test.ts`](diffhunk://#diff-798cc1cdf0624f504f0c596491a6eeaa9b112ef33bc352f0088466373c931bd8R1-R122): Added comprehensive tests for the `FederatedConnectionAuthorizer`, including scenarios for authorization errors and successful authorization.
* [`packages/ai/test/ciba-authorizer-base.test.ts`](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL11-R14): Removed mock implementation class and updated tests to use the base `CIBAAuthorizerBase` class directly. [[1]](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL11-R14) [[2]](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL47-R39) [[3]](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL59-R67)
* [`packages/ai/test/federated-connection-base.test.ts`](diffhunk://#diff-b0b5fcd45b46920ce9e9cfed1ec0c18245053e9842542ea2683f12a3860594d8L8-R13): Removed mock implementation class and updated tests to use the base `FederatedConnectionAuthorizerBase` class directly. [[1]](diffhunk://#diff-b0b5fcd45b46920ce9e9cfed1ec0c18245053e9842542ea2683f12a3860594d8L8-R13) [[2]](diffhunk://#diff-b0b5fcd45b46920ce9e9cfed1ec0c18245053e9842542ea2683f12a3860594d8L34-R25) [[3]](diffhunk://#diff-b0b5fcd45b46920ce9e9cfed1ec0c18245053e9842542ea2683f12a3860594d8L46-R45)

Code Cleanup:

* [`packages/ai/src/authorizers/ciba/index.ts`](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL180-L230): Removed commented-out `poll` method and made the `protect` method non-protected. [[1]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL180-L230) [[2]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL239-R188)