### PR TITLE
chore: add .env.example to vercel-ai-agent demo

### DIFF
--- a/demos/vercel-ai-agent/.env.example
+++ b/demos/vercel-ai-agent/.env.example
@@ -1,0 +1,22 @@
+#Copy this file to .env.local and fill the values
+# Get your OpenAI API Key here for chat models: https://platform.openai.com/account/api-keys
+OPENAI_API_KEY=
+
+#Register and configure an app in Auth0 to get these values
+AUTH0_DOMAIN=
+AUTH0_CLIENT_ID=
+AUTH0_CLIENT_SECRET=
+
+# Redis configuration for the docker instance
+REDISPORT=6379
+REDISHOST=localhost
+QUEUENAME=jobs
+
+# Maildev configuration
+MAILDEV_HTTP_PORT=8045
+SMTP_PORT=1025
+NODE_TLS_REJECT_UNAUTHORIZED=0
+
+# If you are going to run `npm run queue-job` to test:
+TEST_USER_ID=
+TEST_USER_EMAIL=

--- a/demos/vercel-ai-agent/src/queue/index.ts
+++ b/demos/vercel-ai-agent/src/queue/index.ts
@@ -57,9 +57,9 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       qty: Math.floor(Math.random() * 100),
 
       tradeID: id,
-      userID: "google-oauth2|115593114228687151710",
 
-      email: "jose@okta.com",
+      userID: process.env.TEST_USER_ID as string,
+      email: process.env.TEST_USER_EMAIL as string,
 
       condition: {
         metric: "PE",


### PR DESCRIPTION
This pull request includes the addition of a new example environment configuration file for the Vercel AI Agent demo. The file provides placeholders for necessary environment variables and instructions for obtaining the required API keys and configuration values.

Environment configuration:

* [`demos/vercel-ai-agent/.env.example`](diffhunk://#diff-59cebb98f6577e80e498d7f097fc12def99385b346b04d3144fb93191bac9b6aR1-R18): Added example environment configuration file with placeholders for OpenAI API Key, Auth0 configuration, Redis configuration, and Maildev configuration.