### PR TITLE
feat: add FGAAuthorizerBase in @auth0/ai and FGAAuthorizer for @auth0/ai-vercel

### DIFF
--- a/packages/ai-vercel/README.md
+++ b/packages/ai-vercel/README.md
@@ -97,6 +97,44 @@ export const checkUsersCalendar = withCalendarFreeBusyAccess(
 );
 ```
 
+## FGA
+
+```javascript
+import { FGA_AI } from "@auth0/ai-vercel";
+
+const auth0AI = new FGA_AI({
+  apiScheme,
+  apiHost
+  storeId,
+  credentials: {
+    method: CredentialsMethod.ClientCredentials,
+    config: {
+      apiTokenIssuer,
+      clientId,
+      clientSecret,
+    },
+  },
+});
+// Alternatively you can use env variables: `FGA_API_SCHEME`, `FGA_API_HOST`, `FGA_STORE_ID`, `FGA_API_TOKEN_ISSUER`, `FGA_CLIENT_ID` and `FGA_CLIENT_SECRET`
+```
+
+Then initialize the tool wrapper:
+
+```js
+const authorizedTool = fgaAI.withFGA({
+  buildQuery: async ({userID, doc}) => ({ user: userID, object: doc, relation: 'read' })
+}, myAITool);
+
+// Or create a wrapper to apply to tools later
+const authorizer = fgaAI.withFGA({
+  buildQuery: async ({userID, doc}) => ({ user: userID, object: doc, relation: 'read' })
+});
+
+const authorizedTool = authorizer(myAITool);
+```
+
+Note: the parameter gives to the `buildQuery` function are the same provided to the tool's `execute` function.
+
 ## Interruptions
 
 This library includes infrastructure code within the AI SDK to handle a concept called **Interruptions**.

--- a/packages/ai-vercel/src/Auth0AI.ts
+++ b/packages/ai-vercel/src/Auth0AI.ts
@@ -4,7 +4,7 @@ import { AuthenticationClient, AuthenticationClientOptions } from "auth0";
 import { CIBAAuthorizer } from "./CIBA";
 import { FederatedConnectionAuthorizer } from "./FederatedConnections";
 
-type FederatedConnectionAuthorizerParams = Partial<
+type AuthorizerParams = Partial<
   Pick<AuthenticationClientOptions, "domain" | "clientSecret" | "clientId">
 >;
 
@@ -20,7 +20,7 @@ export class Auth0AI {
   readonly clientSecret: string;
   readonly authClient: AuthenticationClient;
 
-  constructor(params: FederatedConnectionAuthorizerParams = {}) {
+  constructor(params: AuthorizerParams = {}) {
     const domain = params.domain || process.env.AUTH0_DOMAIN;
     const clientId = params.clientId || process.env.AUTH0_CLIENT_ID;
     const clientSecret = params.clientSecret || process.env.AUTH0_CLIENT_SECRET;

--- a/packages/ai-vercel/src/FGA/FGAAuthorizer.ts
+++ b/packages/ai-vercel/src/FGA/FGAAuthorizer.ts
@@ -1,0 +1,34 @@
+import { Tool, ToolExecutionOptions } from "ai";
+import { Schema, z } from "zod";
+
+import { FGAAuthorizerBase } from "@auth0/ai/FGA";
+
+type Parameters = z.ZodTypeAny | Schema<any>;
+
+/**
+ * The FGAAuthorizer class implements the FGA authorization control for a Vercel AI tool.
+ *
+ * This class extends the FGAAuthorizerBase and provides a method to build a tool authorizer
+ * that protects the tool execution using FGA.
+ *
+ */
+export class FGAAuthorizer extends FGAAuthorizerBase<
+  [any, ToolExecutionOptions]
+> {
+  /**
+   *
+   * Builds a tool authorizer that protects the tool execution with FGA.
+   *
+   * @returns A tool authorizer.
+   */
+  authorizer() {
+    return <PARAMETERS extends Parameters = any, RESULT = any>(
+      t: Tool<PARAMETERS, RESULT>
+    ): Tool<PARAMETERS, RESULT> => {
+      return {
+        ...t,
+        execute: this.protect(t.execute!),
+      };
+    };
+  }
+}

--- a/packages/ai-vercel/src/FGA/index.ts
+++ b/packages/ai-vercel/src/FGA/index.ts
@@ -1,0 +1,1 @@
+export { FGAAuthorizer } from "./FGAAuthorizer";

--- a/packages/ai-vercel/src/FGA_AI.ts
+++ b/packages/ai-vercel/src/FGA_AI.ts
@@ -1,0 +1,52 @@
+import { Tool } from "ai";
+
+import { FGAAuthorizer } from "./FGA";
+
+type FGAAuthorizerParams = ConstructorParameters<typeof FGAAuthorizer>[0];
+type ToolWrapper = ReturnType<FGAAuthorizer["authorizer"]>;
+type FGAParams = ConstructorParameters<typeof FGAAuthorizer>[1];
+
+/**
+ * A class for integrating Fine-Grained Authorization with AI tools.
+ *
+ * This class provides functionality to wrap AI tools with FGA authorization controls.
+ * It allows for authorization checks to be applied to AI tools before they are used.
+ *
+ * @example
+ * ```typescript
+ * const fgaAI = new FGA_AI({
+ *   apiUrl: 'https://api.fga.example',
+ *   storeId: 'store123',
+ *   credentials: { ... }
+ * });
+ *
+ * // Wrap an existing tool
+ * const authorizedTool = fgaAI.withFGA({
+ *   modelName: 'gpt-4',
+ *   userID: 'user123'
+ * }, myAITool);
+ *
+ * // Or create a wrapper to apply to tools later
+ * const authorizer = fgaAI.withFGA({
+ *   modelName: 'gpt-4',
+ *   userID: 'user123'
+ * });
+ * const authorizedTool = authorizer(myAITool);
+ * ```
+ */
+export class FGA_AI {
+  constructor(private fgaParams: FGAAuthorizerParams) {}
+
+  withFGA(params: FGAParams): ToolWrapper;
+
+  withFGA(params: FGAParams, tool: Tool): Tool;
+
+  withFGA(params: FGAParams, tool?: Tool) {
+    const fc = new FGAAuthorizer(this.fgaParams, params);
+    const authorizer = fc.authorizer();
+    if (tool) {
+      return authorizer(tool);
+    }
+    return authorizer;
+  }
+}

--- a/packages/ai-vercel/src/index.ts
+++ b/packages/ai-vercel/src/index.ts
@@ -1,6 +1,2 @@
-export {
-  FederatedConnectionAuthorizer,
-  getFederatedConnectionAccessToken,
-  FederatedConnectionError
-} from './FederatedConnections';
-export { Auth0AI } from './Auth0AI';
+export { Auth0AI } from "./Auth0AI";
+export { FGA_AI } from "./FGA_AI";

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -33,6 +33,11 @@
       "types": "./dist/authorizers/ciba/index.d.ts",
       "import": "./dist/authorizers/ciba/index.mjs",
       "require": "./dist/authorizers/ciba/index.js"
+    },
+    "./FGA": {
+      "types": "./dist/authorizers/fga/index.d.ts",
+      "import": "./dist/authorizers/fga/index.mjs",
+      "require": "./dist/authorizers/fga/index.js"
     }
   },
   "files": [

--- a/packages/ai/src/authorizers/fga/index.ts
+++ b/packages/ai/src/authorizers/fga/index.ts
@@ -1,0 +1,92 @@
+import {
+  ClientCheckRequest,
+  ConsistencyPreference,
+  CredentialsMethod,
+  OpenFgaClient,
+} from "@openfga/sdk";
+
+export type FGAAuthorizerParams = {
+  name: string;
+  apiUrl?: string;
+  storeId?: string;
+  credentials?: {
+    method: any;
+    config: {
+      apiTokenIssuer: string;
+      apiAudience: string;
+      clientId: string;
+      clientSecret: string;
+    };
+  };
+};
+
+export type FGAAuthorizerOptions<ToolExecuteArgs extends any[]> = {
+  buildQuery: (...args: ToolExecuteArgs) => Promise<ClientCheckRequest>;
+  onUnauthorized?: (...args: ToolExecuteArgs) => any;
+};
+
+export class FGAAuthorizerBase<ToolExecuteArgs extends any[]> {
+  name: string;
+  fgaClient: OpenFgaClient;
+
+  constructor(
+    fgaClientParams: FGAAuthorizerParams | undefined | null,
+    private authorizeOptions: FGAAuthorizerOptions<ToolExecuteArgs>
+  ) {
+    this.name = fgaClientParams?.name || "fga";
+    this.fgaClient = new OpenFgaClient({
+      apiUrl:
+        fgaClientParams?.apiUrl ||
+        process.env.FGA_API_URL ||
+        "https://api.us1.fga.dev",
+      storeId: fgaClientParams?.storeId || process.env.FGA_STORE_ID!,
+      credentials: {
+        method:
+          fgaClientParams?.credentials?.method ||
+          CredentialsMethod.ClientCredentials,
+        config: {
+          apiTokenIssuer:
+            fgaClientParams?.credentials?.config.apiTokenIssuer ||
+            process.env.FGA_API_TOKEN_ISSUER ||
+            "fga.us.auth0.com",
+          apiAudience:
+            fgaClientParams?.credentials?.config.apiAudience ||
+            process.env.FGA_API_AUDIENCE ||
+            "https://api.us1.fga.dev/",
+          clientId:
+            fgaClientParams?.credentials?.config.clientId ||
+            process.env.FGA_CLIENT_ID!,
+          clientSecret:
+            fgaClientParams?.credentials?.config.clientSecret ||
+            process.env.FGA_CLIENT_SECRET!,
+        },
+      },
+    });
+  }
+
+  /**
+   *
+   * Wraps the execute method of an AI tool to handle FGA authorization.
+   *
+   * @param execute - The tool execute method.
+   * @returns The wrapped execute method.
+   */
+  protect(
+    execute: (...args: ToolExecuteArgs) => any
+  ): (...args: ToolExecuteArgs) => any {
+    return async (...args: ToolExecuteArgs) => {
+      const check = await this.authorizeOptions.buildQuery(...args);
+      const { allowed } = await this.fgaClient.check(check, {
+        consistency: ConsistencyPreference.HigherConsistency,
+      });
+      if (!allowed) {
+        if (typeof this.authorizeOptions.onUnauthorized === "function") {
+          return this.authorizeOptions.onUnauthorized(...args);
+        } else {
+          return "The user is not allowed to perform the action.";
+        }
+      }
+      return execute(...args);
+    };
+  }
+}

--- a/packages/ai/src/parameters.ts
+++ b/packages/ai/src/parameters.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
+const isCallback = (
+  maybeFunction: any | ((...args: any[]) => void)
+): maybeFunction is Function => typeof maybeFunction === "function";
+
+export type AuthorizerToolParameter<
+  ToolExecuteArgs extends any[],
+  TResult = string
+> = TResult | ((...args: ToolExecuteArgs) => Promise<TResult> | TResult);
+
+export const resolveParameter = <
+  ToolExecuteArgs extends any[],
+  TResult = string
+>(
+  resolver: AuthorizerToolParameter<ToolExecuteArgs, TResult>,
+  context: ToolExecuteArgs
+): TResult | Promise<TResult> => {
+  if (isCallback(resolver)) {
+    return resolver(...context);
+  }
+  return resolver;
+};

--- a/packages/ai/test/fga-authorizer-base.test.ts
+++ b/packages/ai/test/fga-authorizer-base.test.ts
@@ -1,0 +1,503 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ClientCheckRequest,
+  ConsistencyPreference,
+  CredentialsMethod,
+  OpenFgaClient,
+} from "@openfga/sdk";
+
+import { FGAAuthorizerBase, FGAAuthorizerParams } from "../src/authorizers/fga";
+
+vi.mock("@openfga/sdk", () => {
+  return {
+    OpenFgaClient: vi.fn().mockImplementation(() => ({
+      check: vi.fn(),
+    })),
+    ConsistencyPreference: {
+      HigherConsistency: "HIGHER_CONSISTENCY",
+    },
+    CredentialsMethod: {
+      ClientCredentials: "client_credentials",
+    },
+  };
+});
+
+describe("FGAAuthorizerBase", () => {
+  const mockCheck = vi.fn();
+  const MockedOpenFgaClient = OpenFgaClient as any;
+
+  beforeEach(() => {
+    MockedOpenFgaClient.mockImplementation(() => ({
+      check: mockCheck,
+    }));
+
+    delete process.env.FGA_API_URL;
+    delete process.env.FGA_STORE_ID;
+    delete process.env.FGA_API_TOKEN_ISSUER;
+    delete process.env.FGA_API_AUDIENCE;
+    delete process.env.FGA_CLIENT_ID;
+    delete process.env.FGA_CLIENT_SECRET;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should initialize with default parameters when no params are provided", async () => {
+      process.env.FGA_API_URL = "https://env.api.url";
+      process.env.FGA_STORE_ID = "env_store_id";
+      process.env.FGA_API_TOKEN_ISSUER = "env_token_issuer";
+      process.env.FGA_API_AUDIENCE = "env_audience";
+      process.env.FGA_CLIENT_ID = "env_client_id";
+      process.env.FGA_CLIENT_SECRET = "env_client_secret";
+
+      mockCheck.mockResolvedValue({ allowed: true });
+
+      const buildQueryMock = vi.fn().mockResolvedValue({
+        user: "user",
+        relation: "relation",
+        object: "object",
+      } as ClientCheckRequest);
+
+      const options = {
+        buildQuery: buildQueryMock,
+      };
+
+      new FGAAuthorizerBase(null, options);
+
+      // Assertions
+      expect(OpenFgaClient).toHaveBeenCalledWith({
+        apiUrl: "https://env.api.url",
+        storeId: "env_store_id",
+        credentials: {
+          method: CredentialsMethod.ClientCredentials,
+          config: {
+            apiTokenIssuer: "env_token_issuer",
+            apiAudience: "env_audience",
+            clientId: "env_client_id",
+            clientSecret: "env_client_secret",
+          },
+        },
+      });
+    });
+
+    it("should initialize with provided parameters", async () => {
+      const params: FGAAuthorizerParams = {
+        name: "custom_fga",
+        apiUrl: "https://custom.api.url",
+        storeId: "custom_store_id",
+        credentials: {
+          method: "custom_method",
+          config: {
+            apiTokenIssuer: "custom_token_issuer",
+            apiAudience: "custom_audience",
+            clientId: "custom_client_id",
+            clientSecret: "custom_client_secret",
+          },
+        },
+      };
+
+      const buildQueryMock = vi.fn().mockResolvedValue({
+        user: "user",
+        relation: "relation",
+        object: "object",
+      } as ClientCheckRequest);
+
+      const options = {
+        buildQuery: buildQueryMock,
+      };
+
+      new FGAAuthorizerBase(params, options);
+
+      // Assertions
+      expect(OpenFgaClient).toHaveBeenCalledWith({
+        apiUrl: "https://custom.api.url",
+        storeId: "custom_store_id",
+        credentials: {
+          method: "custom_method",
+          config: {
+            apiTokenIssuer: "custom_token_issuer",
+            apiAudience: "custom_audience",
+            clientId: "custom_client_id",
+            clientSecret: "custom_client_secret",
+          },
+        },
+      });
+    });
+
+    it("should fallback to environment variables when params are missing", async () => {
+      process.env.FGA_API_URL = "https://env.api.url";
+      process.env.FGA_API_TOKEN_ISSUER = "env_token_issuer";
+      process.env.FGA_API_AUDIENCE = "env_audience";
+      process.env.FGA_CLIENT_ID = "env_client_id";
+      process.env.FGA_CLIENT_SECRET = "env_client_secret";
+
+      const params: FGAAuthorizerParams = {
+        name: "partial_fga",
+        storeId: "partial_store_id",
+      };
+
+      const buildQueryMock = vi.fn().mockResolvedValue({
+        user: "user",
+        relation: "relation",
+        object: "object",
+      } as ClientCheckRequest);
+
+      const options = {
+        buildQuery: buildQueryMock,
+      };
+
+      new FGAAuthorizerBase(params, options);
+
+      // Assertions
+      expect(OpenFgaClient).toHaveBeenCalledWith({
+        apiUrl: "https://env.api.url",
+        storeId: "partial_store_id",
+        credentials: {
+          method: CredentialsMethod.ClientCredentials,
+          config: {
+            apiTokenIssuer: "env_token_issuer",
+            apiAudience: "env_audience",
+            clientId: "env_client_id",
+            clientSecret: "env_client_secret",
+          },
+        },
+      });
+    });
+
+    it("should handle missing environment variables gracefully", async () => {
+      process.env.FGA_STORE_ID = "env_store_id";
+
+      const params: FGAAuthorizerParams = {
+        name: "partial_fga",
+      };
+
+      const buildQueryMock = vi.fn().mockResolvedValue({
+        user: "user",
+        relation: "relation",
+        object: "object",
+      } as ClientCheckRequest);
+
+      const options = {
+        buildQuery: buildQueryMock,
+      };
+
+      new FGAAuthorizerBase(params, options);
+
+      // Assertions
+      expect(OpenFgaClient).toHaveBeenCalledWith({
+        apiUrl: "https://api.us1.fga.dev",
+        storeId: "env_store_id",
+        credentials: {
+          method: CredentialsMethod.ClientCredentials,
+          config: {
+            clientId: undefined,
+            clientSecret: undefined,
+            apiAudience: "https://api.us1.fga.dev/",
+            apiTokenIssuer: "fga.us.auth0.com",
+          },
+        },
+      });
+    });
+  });
+
+  describe("when authorized", () => {
+    const toolExecute = vi.fn();
+    const toolParameters = { user: "user", object: "123", relation: "read" };
+    const buildQuery = vi.fn();
+
+    beforeEach(async () => {
+      mockCheck.mockResolvedValue({ allowed: true });
+      buildQuery.mockResolvedValue(toolParameters);
+      const authorizer = new FGAAuthorizerBase(
+        {
+          name: "test_fga",
+          storeId: "test_store_id",
+        },
+        {
+          buildQuery: buildQuery,
+        }
+      );
+      const protectedExecute = authorizer.protect(toolExecute);
+      await protectedExecute(toolParameters, {});
+    });
+
+    it("should call the execute function", () => {
+      expect(toolExecute).toHaveBeenCalled();
+    });
+
+    it("should call the buildQuery function", () => {
+      expect(buildQuery).toHaveBeenCalledWith(toolParameters, {});
+    });
+
+    it("should call check with the correct parameters", () => {
+      expect(mockCheck).toHaveBeenCalledWith(toolParameters, {
+        consistency: ConsistencyPreference.HigherConsistency,
+      });
+    });
+  });
+
+  describe("when not authorized", () => {
+    const toolExecute = vi.fn();
+    const toolParameters = { user: "user", object: "123", relation: "read" };
+    const buildQuery = vi.fn();
+    let result: any;
+
+    beforeEach(async () => {
+      mockCheck.mockResolvedValue({ allowed: false });
+      buildQuery.mockResolvedValue(toolParameters);
+      const authorizer = new FGAAuthorizerBase(
+        {
+          name: "test_fga",
+          storeId: "test_store_id",
+        },
+        {
+          buildQuery: buildQuery,
+        }
+      );
+      const protectedExecute = authorizer.protect(toolExecute);
+      result = await protectedExecute(toolParameters, {});
+    });
+
+    it("should not call the execute function", () => {
+      expect(toolExecute).not.toHaveBeenCalled();
+    });
+
+    it("should return the default result", () => {
+      expect(result).toMatchInlineSnapshot(
+        `"The user is not allowed to perform the action."`
+      );
+    });
+
+    it("should call the buildQuery function", () => {
+      expect(buildQuery).toHaveBeenCalledWith(toolParameters, {});
+    });
+
+    it("should call check with the correct parameters", () => {
+      expect(mockCheck).toHaveBeenCalledWith(toolParameters, {
+        consistency: ConsistencyPreference.HigherConsistency,
+      });
+    });
+  });
+
+  describe("when not authorized and custom onUnauthorized function is provided", () => {
+    const toolExecute = vi.fn();
+    const toolParameters = { user: "user", object: "123", relation: "read" };
+    const buildQuery = vi.fn();
+    const onUnauthorized = vi.fn();
+    let result: any;
+
+    beforeEach(async () => {
+      mockCheck.mockResolvedValue({ allowed: false });
+      buildQuery.mockResolvedValue(toolParameters);
+      onUnauthorized.mockResolvedValue("User not allowed");
+      const authorizer = new FGAAuthorizerBase(
+        {
+          name: "test_fga",
+          storeId: "test_store_id",
+        },
+        {
+          buildQuery: buildQuery,
+          onUnauthorized,
+        }
+      );
+      const protectedExecute = authorizer.protect(toolExecute);
+      result = await protectedExecute(toolParameters, {});
+    });
+
+    it("should not call the execute function", () => {
+      expect(toolExecute).not.toHaveBeenCalled();
+    });
+
+    it("should return the expected result", () => {
+      expect(result).toMatchInlineSnapshot(`"User not allowed"`);
+    });
+
+    it("should call the onUnauthorized function", () => {
+      expect(onUnauthorized).toHaveBeenCalledWith(toolParameters, {});
+    });
+
+    it("should call the buildQuery function", () => {
+      expect(buildQuery).toHaveBeenCalledWith(toolParameters, {});
+    });
+
+    it("should call check with the correct parameters", () => {
+      expect(mockCheck).toHaveBeenCalledWith(toolParameters, {
+        consistency: ConsistencyPreference.HigherConsistency,
+      });
+    });
+  });
+
+  // it("should authorize and allow handler execution when allowed is true", async () => {
+
+  // describe("Authorization Flow via create method", () => {
+  //   it("should authorize and allow handler execution when allowed is true", async () => {
+  //     const params: FGAAuthorizerParams = {
+  //       name: "test_fga",
+  //       storeId: "test_store_id",
+  //     };
+
+  //     mockCheck.mockResolvedValue({ allowed: true });
+
+  //     const createAuthorizer = FGAAuthorizer.create(params);
+
+  //     const buildQueryMock = vi.fn().mockResolvedValue({
+  //       user: "user",
+  //       relation: "relation",
+  //       object: "object",
+  //     } as ClientCheckRequest);
+
+  //     const options: FGAAuthorizerOptions = {
+  //       buildQuery: buildQueryMock,
+  //     };
+
+  //     const handler: ToolWithAuthHandler<{ allowed?: boolean }, string, any> =
+  //       vi.fn().mockResolvedValue("handler_result");
+
+  //     const wrappedHandler = createAuthorizer(options)(handler);
+
+  //     const input: any = { userId: "user123", resourceId: "res456" };
+
+  //     const result = await wrappedHandler(input, undefined);
+
+  //     // Assertions
+  //     expect(buildQueryMock).toHaveBeenCalledWith(input);
+  //     expect(OpenFgaClient).toHaveBeenCalled();
+  //     expect(mockCheck).toHaveBeenCalledWith(
+  //       { user: "user", relation: "relation", object: "object" },
+  //       { consistency: ConsistencyPreference.HigherConsistency }
+  //     );
+  //     expect(handler).toHaveBeenCalledWith({ allowed: true }, input, undefined);
+  //     expect(result).toBe("handler_result");
+  //   });
+
+  //   it("should authorize and pass allowed as false when authorization fails", async () => {
+  //     const params: FGAAuthorizerParams = {
+  //       name: "test_fga",
+  //       storeId: "test_store_id",
+  //     };
+
+  //     mockCheck.mockResolvedValue({ allowed: false });
+
+  //     const createAuthorizer = FGAAuthorizer.create(params);
+
+  //     const buildQueryMock = vi.fn().mockResolvedValue({
+  //       user: "user",
+  //       relation: "relation",
+  //       object: "object",
+  //     } as ClientCheckRequest);
+
+  //     const options: FGAAuthorizerOptions = {
+  //       buildQuery: buildQueryMock,
+  //     };
+
+  //     const handler: ToolWithAuthHandler<{ allowed?: boolean }, string, any> =
+  //       vi.fn().mockResolvedValue("handler_result");
+
+  //     const wrappedHandler = createAuthorizer(options)(handler);
+
+  //     const input: any = { userId: "user123", resourceId: "res456" };
+
+  //     const result = await wrappedHandler(input, undefined);
+
+  //     // Assertions
+  //     expect(buildQueryMock).toHaveBeenCalledWith(input);
+  //     expect(OpenFgaClient).toHaveBeenCalled();
+  //     expect(mockCheck).toHaveBeenCalledWith(
+  //       { user: "user", relation: "relation", object: "object" },
+  //       { consistency: ConsistencyPreference.HigherConsistency }
+  //     );
+  //     expect(handler).toHaveBeenCalledWith(
+  //       { allowed: false },
+  //       input,
+  //       undefined
+  //     );
+  //     expect(result).toBe("handler_result");
+  //   });
+
+  //   it("should propagate errors from authorization", async () => {
+  //     const params: FGAAuthorizerParams = {
+  //       name: "test_fga",
+  //       storeId: "test_store_id",
+  //     };
+
+  //     mockCheck.mockRejectedValue(new Error("FGA check failed"));
+
+  //     const createAuthorizer = FGAAuthorizer.create(params);
+
+  //     const buildQueryMock = vi.fn().mockResolvedValue({
+  //       user: "user",
+  //       relation: "relation",
+  //       object: "object",
+  //     } as ClientCheckRequest);
+
+  //     const options: FGAAuthorizerOptions = {
+  //       buildQuery: buildQueryMock,
+  //     };
+
+  //     const handler: ToolWithAuthHandler<{ allowed?: boolean }, string, any> =
+  //       vi.fn();
+
+  //     const wrappedHandler = createAuthorizer(options)(handler);
+
+  //     const input: any = { userId: "user123", resourceId: "res456" };
+
+  //     await expect(wrappedHandler(input, undefined)).resolves.toBe(
+  //       "The user is not allowed to perform the action."
+  //     );
+
+  //     // Assertions
+  //     expect(buildQueryMock).toHaveBeenCalledWith(input);
+  //     expect(OpenFgaClient).toHaveBeenCalled();
+  //     expect(mockCheck).toHaveBeenCalledWith(
+  //       { user: "user", relation: "relation", object: "object" },
+  //       { consistency: ConsistencyPreference.HigherConsistency }
+  //     );
+  //     expect(handler).not.toHaveBeenCalled();
+  //   });
+
+  //   it("should handle undefined toolContext gracefully", async () => {
+  //     const params: FGAAuthorizerParams = {
+  //       name: "test_fga",
+  //       storeId: "test_store_id",
+  //     };
+
+  //     mockCheck.mockResolvedValue({ allowed: true });
+
+  //     const createAuthorizer = FGAAuthorizer.create(params);
+
+  //     const buildQueryMock = vi.fn().mockResolvedValue({
+  //       user: "user",
+  //       relation: "relation",
+  //       object: "object",
+  //     } as ClientCheckRequest);
+
+  //     const options: FGAAuthorizerOptions = {
+  //       buildQuery: buildQueryMock,
+  //     };
+
+  //     const handler: ToolWithAuthHandler<{ allowed?: boolean }, string, any> =
+  //       vi.fn().mockResolvedValue("handler_result");
+
+  //     const wrappedHandler = createAuthorizer(options)(handler);
+
+  //     const result = await wrappedHandler(undefined as any, undefined);
+
+  //     // Assertions
+  //     expect(buildQueryMock).toHaveBeenCalledWith({});
+  //     expect(OpenFgaClient).toHaveBeenCalled();
+  //     expect(mockCheck).toHaveBeenCalledWith(
+  //       { user: "user", relation: "relation", object: "object" },
+  //       { consistency: ConsistencyPreference.HigherConsistency }
+  //     );
+  //     expect(handler).toHaveBeenCalledWith(
+  //       { allowed: true },
+  //       undefined,
+  //       undefined
+  //     );
+  //     expect(result).toBe("handler_result");
+  //   });
+  // });
+});

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig([
       "src/index.ts",
       "src/authorizers/federated-connections/index.ts",
       "src/authorizers/ciba/index.ts",
+      "src/authorizers/fga/index.ts",
     ],
     format: ["cjs", "esm"],
     dts: true,


### PR DESCRIPTION
This pull request introduces several significant changes to the `ai-vercel` package, focusing on adding Fine-Grained Authorization (FGA) support and refactoring existing authorizers. The most important changes include adding a new FGA authorizer, updating the `Auth0AI` class to use a more generic parameter type, and refactoring the existing CIBA and Federated Connection authorizers to use a new parameter resolution utility.

### New Features:
* [`packages/ai-vercel/src/FGA/FGAAuthorizer.ts`](diffhunk://#diff-5efa2d654056ea2400cdf06315825a07398a2e6ac7dceeeb8ef7305aff6f7a11R1-R34): Introduced the `FGAAuthorizer` class, which implements FGA authorization control for AI tools.
* [`packages/ai-vercel/src/FGA_AI.ts`](diffhunk://#diff-0624e89037a24d1a91918660e0a99cc5c59142a5b3b9ef0a417aa0b640650953R1-R52): Added the `FGA_AI` class for integrating Fine-Grained Authorization with AI tools, providing functionality to wrap AI tools with FGA authorization controls.
* [`packages/ai-vercel/src/FGA/index.ts`](diffhunk://#diff-ed3663fabd7f84950e73656564c249e34188201f5bc1cec3d10dd59699a6433bR1): Exported the `FGAAuthorizer` class.
* [`packages/ai-vercel/README.md`](diffhunk://#diff-6c7b20f5b315d5227899a28d3b17d1fd20266b33e2bb028eb4be0708458a79aeR100-R137): Updated the README to include examples and documentation for using the new FGA authorization features.

### Refactoring:
* [`packages/ai-vercel/src/Auth0AI.ts`](diffhunk://#diff-d5d9b6e61e338fbeeb2ca081e2eb349d8d1c0b5aec7565b4c44344e65dcea8a0L7-R7): Updated the `Auth0AI` class to use the more generic `AuthorizerParams` type instead of `FederatedConnectionAuthorizerParams`. [[1]](diffhunk://#diff-d5d9b6e61e338fbeeb2ca081e2eb349d8d1c0b5aec7565b4c44344e65dcea8a0L7-R7) [[2]](diffhunk://#diff-d5d9b6e61e338fbeeb2ca081e2eb349d8d1c0b5aec7565b4c44344e65dcea8a0L23-R23)
* [`packages/ai/src/parameters.ts`](diffhunk://#diff-3aa0e48dfb11ee472c9128d5d634c5e7da05a35f22efe18ef407a3dc95f0aa9dR1-R22): Added a new utility for resolving parameters, `resolveParameter`, and a new type `AuthorizerToolParameter` to simplify parameter handling in authorizers.

### Updates to Existing Authorizers:
* [`packages/ai/src/authorizers/ciba/index.ts`](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfR3): Refactored the CIBA authorizer to use the new `resolveParameter` utility and `AuthorizerToolParameter` type. [[1]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfR3) [[2]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL26-R29) [[3]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL55-R38) [[4]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL121-R109) [[5]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL193-R176)
* [`packages/ai/src/authorizers/federated-connections/index.ts`](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L1-R2): Refactored the Federated Connection authorizer to use the new `resolveParameter` utility and `AuthorizerToolParameter` type. [[1]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L1-R2) [[2]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L12-R14) [[3]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L51-R50) [[4]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L68-R68) [[5]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L117-R115)

### Miscellaneous:
* [`packages/ai/package.json`](diffhunk://#diff-3758ea4fd63e4789bf712baab7b4b0227fce843a17e2ed535091b9c3b83ff2dfR36-R40): Added the new FGA authorizer to the package exports.
* [`packages/ai/tsup.config.ts`](diffhunk://#diff-32e50584d3c65671eba90438af4aa48d47668ea14c93fec076fc532e45440b58R9): Included the new FGA authorizer in the build configuration.
* [`packages/ai-vercel/src/index.ts`](diffhunk://#diff-cd94228cd80524f6886f2c431d15658cd666d1f9ce66d4efb4bf41d01220cf38L1-R2): Exported the new `FGA_AI` class.FGAAuthorizer to @auth0/ai-vercel