### PR TITLE
chore: improve ciba docs and sample

### DIFF
--- a/demos/vercel-ai-agent/src/tools/buySock.ts
+++ b/demos/vercel-ai-agent/src/tools/buySock.ts
@@ -1,14 +1,25 @@
 import { z } from "zod";
 
+import { getCIBACredentials } from "@auth0/ai-vercel";
+
 import { withCIBA } from "../auth0ai";
 
 export const buyStock = withCIBA({
   description: "Execute an stock purchase given stock ticker and quantity",
   parameters: z.object({
-    tradeID: z.string().uuid().describe('The unique identifier for the trade provided by the user'),
-    userID: z.string().describe('The user ID of the user who created the conditional trade'),
-    ticker: z.string().describe('The stock ticker to trade'),
-    qty: z.number().int().positive().describe('The quantity of shares to trade'),
+    tradeID: z
+      .string()
+      .uuid()
+      .describe("The unique identifier for the trade provided by the user"),
+    userID: z
+      .string()
+      .describe("The user ID of the user who created the conditional trade"),
+    ticker: z.string().describe("The stock ticker to trade"),
+    qty: z
+      .number()
+      .int()
+      .positive()
+      .describe("The quantity of shares to trade"),
   }),
   execute: async (
     {
@@ -22,6 +33,10 @@ export const buyStock = withCIBA({
     },
     ctx
   ): Promise<string> => {
+    const credentials = getCIBACredentials();
+    console.log(
+      `The token obtained with ciba is ${credentials?.accessToken?.value}`
+    );
     return `Just bought ${qty} shares of ${ticker} for ${userID}`;
   },
 });

--- a/packages/ai-vercel/src/CIBA/index.ts
+++ b/packages/ai-vercel/src/CIBA/index.ts
@@ -1,3 +1,3 @@
 export { CIBAAuthorizer } from "./CIBAAuthorizer";
 export { CIBAuthorizationError } from "./CIBAuthorizationError";
-export { getCIBACredentials as getFederatedConnectionAccessToken } from "./getCIBACredentials";
+export { getCIBACredentials } from "./getCIBACredentials";

--- a/packages/ai-vercel/src/index.ts
+++ b/packages/ai-vercel/src/index.ts
@@ -1,2 +1,4 @@
 export { Auth0AI } from "./Auth0AI";
 export { FGA_AI } from "./FGA_AI";
+export { getCIBACredentials } from "./CIBA";
+export { getFederatedConnectionAccessToken } from "./FederatedConnections";


### PR DESCRIPTION
This pull request introduces several changes related to the integration of Client Initiated Backchannel Authentication (CIBA) in the `ai-vercel` package and its usage in the `vercel-ai-agent` demo. The main updates include importing and using the `getCIBACredentials` function, updating the `buyStock` tool, and enhancing documentation with examples of using CIBA.

### Integration of CIBA:

* [`demos/vercel-ai-agent/src/tools/buySock.ts`](diffhunk://#diff-d961e96c50d00b93aa9adb919e04172fcfad84b92d7d823afdfdf3f009477792R3-R22): Imported the `getCIBACredentials` function and added its usage to log the access token obtained with CIBA during the execution of the `buyStock` tool. [[1]](diffhunk://#diff-d961e96c50d00b93aa9adb919e04172fcfad84b92d7d823afdfdf3f009477792R3-R22) [[2]](diffhunk://#diff-d961e96c50d00b93aa9adb919e04172fcfad84b92d7d823afdfdf3f009477792R36-R39)

### Documentation updates:

* [`packages/ai-vercel/README.md`](diffhunk://#diff-6c7b20f5b315d5227899a28d3b17d1fd20266b33e2bb028eb4be0708458a79aeR100-R162): Added a new section on CIBA, including a detailed example of how to use the `auth0AI.withCIBA` function to authorize stock purchases.

### Codebase adjustments:

* [`packages/ai-vercel/src/CIBA/index.ts`](diffhunk://#diff-271ad1ed172375899791c31d173fd1fc31e1b37738672f5fe35c79c1ca96f0c8L3-R3): Updated the export statement to directly export `getCIBACredentials` instead of renaming it to `getFederatedConnectionAccessToken`.
* [`packages/ai-vercel/src/index.ts`](diffhunk://#diff-cd94228cd80524f6886f2c431d15658cd666d1f9ce66d4efb4bf41d01220cf38R3-R4): Added exports for `getCIBACredentials` and `getFederatedConnectionAccessToken` to the main index file.