### PR TITLE
chore: remove subjectIssuerContext parameter

### DIFF
--- a/packages/ai/src/authorizers/ciba-authorizer.ts
+++ b/packages/ai/src/authorizers/ciba-authorizer.ts
@@ -13,7 +13,6 @@ export type CibaAuthorizerOptions = {
   scope: string;
   audience?: string;
   requestExpiry?: string;
-  subjectIssuerContext?: string;
 };
 
 export enum CibaAuthorizerCheckResponse {
@@ -80,7 +79,6 @@ export class CIBAAuthorizer {
       userId: "",
       audience: params.audience || "",
       request_expiry: params.requestExpiry,
-      subjectIssuerContext: params.subjectIssuerContext,
     };
 
     if (typeof params.bindingMessage === "function") {

--- a/packages/ai/src/authorizers/ciba/index.ts
+++ b/packages/ai/src/authorizers/ciba/index.ts
@@ -30,7 +30,6 @@ export type CIBAAuthorizerParams<ToolExecuteArgs extends any[]> = {
   scope: string;
   audience?: string;
   requestExpiry?: string;
-  subjectIssuerContext?: string;
 
   /**
    * Given a tool context returns the authorization request data.
@@ -98,7 +97,6 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
       userId: "",
       audience: this.params.audience || "",
       request_expiry: this.params.requestExpiry,
-      subjectIssuerContext: this.params.subjectIssuerContext,
     };
 
     authorizeParams.binding_message = await resolveParameter(

--- a/packages/ai/test/ciba-authorizer.test.ts
+++ b/packages/ai/test/ciba-authorizer.test.ts
@@ -119,7 +119,6 @@ describe("CIBAAuthorizer", () => {
       userId: "dynamic-user-id",
       audience: "",
       request_expiry: undefined,
-      subjectIssuerContext: undefined,
     });
   });
 });


### PR DESCRIPTION
This pull request includes several changes to the `CIBAAuthorizer` and related classes to remove the `subjectIssuerContext` parameter. The most important changes are as follows:

Removal of `subjectIssuerContext` parameter:

* [`packages/ai/src/authorizers/ciba-authorizer.ts`](diffhunk://#diff-251f2a3ff9bd69fa8f227004619422bbce40825076d5394df5424c24202c4958L16): Removed the `subjectIssuerContext` field from the `CibaAuthorizerOptions` type and the `CIBAAuthorizer` class. [[1]](diffhunk://#diff-251f2a3ff9bd69fa8f227004619422bbce40825076d5394df5424c24202c4958L16) [[2]](diffhunk://#diff-251f2a3ff9bd69fa8f227004619422bbce40825076d5394df5424c24202c4958L83)
* [`packages/ai/src/authorizers/ciba/index.ts`](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL33): Removed the `subjectIssuerContext` field from the `CIBAAuthorizerParams` type and the `CIBAAuthorizerBase` class. [[1]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL33) [[2]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL101)
* [`packages/ai/test/ciba-authorizer.test.ts`](diffhunk://#diff-163fcc12fecb77895939a287467fb41fcbd3fc2f5b4dc61865fb6efe72cc98b2L122): Updated tests to reflect the removal of the `subjectIssuerContext` field.