### PR TITLE
chore: change requestExpiry to number

### DIFF
--- a/packages/ai/src/authorizers/ciba-authorizer.ts
+++ b/packages/ai/src/authorizers/ciba-authorizer.ts
@@ -12,7 +12,7 @@ export type CibaAuthorizerOptions = {
   bindingMessage: string | StringOrFn;
   scope: string;
   audience?: string;
-  requestExpiry?: string;
+  requestExpiry?: number;
 };
 
 export enum CibaAuthorizerCheckResponse {
@@ -78,7 +78,7 @@ export class CIBAAuthorizer {
       binding_message: "",
       userId: "",
       audience: params.audience || "",
-      request_expiry: params.requestExpiry,
+      request_expiry: params.requestExpiry?.toString(),
     };
 
     if (typeof params.bindingMessage === "function") {

--- a/packages/ai/src/authorizers/ciba/index.ts
+++ b/packages/ai/src/authorizers/ciba/index.ts
@@ -29,7 +29,7 @@ export type CIBAAuthorizerParams<ToolExecuteArgs extends any[]> = {
   bindingMessage: AuthorizerToolParameter<ToolExecuteArgs>;
   scope: string;
   audience?: string;
-  requestExpiry?: string;
+  requestExpiry?: number;
 
   /**
    * Given a tool context returns the authorization request data.
@@ -96,7 +96,7 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
       binding_message: "",
       userId: "",
       audience: this.params.audience || "",
-      request_expiry: this.params.requestExpiry,
+      request_expiry: this.params.requestExpiry?.toString(),
     };
 
     authorizeParams.binding_message = await resolveParameter(


### PR DESCRIPTION
This pull request includes changes to the `CIBAAuthorizer` and `CIBAAuthorizerBase` classes to improve type consistency and ensure correct data handling. The most important changes include updating the type of `requestExpiry` from `string` to `number` and modifying how `requestExpiry` is converted to a string.

Type and data handling improvements:

* [`packages/ai/src/authorizers/ciba-authorizer.ts`](diffhunk://#diff-251f2a3ff9bd69fa8f227004619422bbce40825076d5394df5424c24202c4958L15-R15): Changed the type of `requestExpiry` from `string` to `number` in the `CibaAuthorizerOptions` type and updated the `CIBAAuthorizer` class to convert `requestExpiry` to a string. [[1]](diffhunk://#diff-251f2a3ff9bd69fa8f227004619422bbce40825076d5394df5424c24202c4958L15-R15) [[2]](diffhunk://#diff-251f2a3ff9bd69fa8f227004619422bbce40825076d5394df5424c24202c4958L81-R81)
* [`packages/ai/src/authorizers/ciba/index.ts`](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL32-R32): Changed the type of `requestExpiry` from `string` to `number` in the `CIBAAuthorizerParams` type and updated the `CIBAAuthorizerBase` class to convert `requestExpiry` to a string. [[1]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL32-R32) [[2]](diffhunk://#diff-64aa1fc9124be7b785813e646ba898b75319273a56d4d40e5930da093cd492cfL99-R99)