### PR TITLE
chore: add lint to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,10 @@ jobs:
         id: npm-ci
         run: npm ci
 
+      - name: Lint
+        id: npm-lint
+        run: npm run lint
+
       - name: Test build
         id: npm-build
         run: npm run build
@@ -39,3 +43,4 @@ jobs:
       - name: Test
         id: npm-test
         run: npm run test
+

--- a/demos/nextjs-ai/package.json
+++ b/demos/nextjs-ai/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "start": "next start",
-    "lint": "next lint"
+    "start": "next start"
   },
   "author": {
     "name": "Auth0 Inc.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1460,6 +1460,44 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint/config-array": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.1.0.tgz",
+      "integrity": "sha512-kLrdPDJE1ckPo94kmPPf9Hfd0DU0Jw6oKYrhe+pwSC0iTUInmTa+w6fw8sGgcfkFJGNdWOUeOaDM4quW4a7OkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
@@ -1506,6 +1544,30 @@
       "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.12.0",
+        "levn": "^0.4.1"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -1681,6 +1743,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1718,6 +1818,20 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
@@ -4007,6 +4121,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.12.tgz",
@@ -4270,8 +4393,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -5673,6 +5795,12 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
     "node_modules/cliui": {
@@ -11623,6 +11751,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -13138,7 +13289,9 @@
         "z": "1.0.1"
       },
       "devDependencies": {
+        "@eslint/compat": "^1.2.7",
         "@types/node": "^22.10.6",
+        "eslint": "^9.22.0",
         "tsup": "^8.3.6",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
@@ -13146,6 +13299,197 @@
       },
       "peerDependencies": {
         "@openfga/sdk": "^0.8.0"
+      }
+    },
+    "packages/ai-genkit/node_modules/@eslint/compat": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.7.tgz",
+      "integrity": "sha512-xvv7hJE32yhegJ8xNAnb62ggiAwTYHBpUCWhRxEj/ksvgDJuSXfoDkBcRYaYNFiJ+jH0IE3K16hd+xXzhBgNbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.10.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-genkit/node_modules/@eslint/eslintrc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-genkit/node_modules/eslint": {
+      "version": "9.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.22.0.tgz",
+      "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.1.0",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.22.0",
+        "@eslint/plugin-kit": "^0.2.7",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-genkit/node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-genkit/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-genkit/node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-genkit/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "packages/ai-genkit/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/ai-genkit/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/ai-genkit/node_modules/z": {
@@ -13167,7 +13511,9 @@
         "z": "1.0.1"
       },
       "devDependencies": {
+        "@eslint/compat": "^1.2.7",
         "@types/node": "^22.10.6",
+        "eslint": "^9.22.0",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
         "vitest": "^3.0.8"
@@ -13184,6 +13530,197 @@
     "packages/ai-langchain/node_modules/@auth0/ai": {
       "resolved": "packages/ai-langchain/@auth0/ai:*",
       "link": true
+    },
+    "packages/ai-langchain/node_modules/@eslint/compat": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.7.tgz",
+      "integrity": "sha512-xvv7hJE32yhegJ8xNAnb62ggiAwTYHBpUCWhRxEj/ksvgDJuSXfoDkBcRYaYNFiJ+jH0IE3K16hd+xXzhBgNbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.10.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-langchain/node_modules/@eslint/eslintrc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-langchain/node_modules/eslint": {
+      "version": "9.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.22.0.tgz",
+      "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.1.0",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.22.0",
+        "@eslint/plugin-kit": "^0.2.7",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-langchain/node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-langchain/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-langchain/node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-langchain/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "packages/ai-langchain/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/ai-langchain/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/ai-langchain/node_modules/z": {
       "version": "1.0.1",
@@ -13206,7 +13743,9 @@
         "z": "1.0.1"
       },
       "devDependencies": {
+        "@eslint/compat": "^1.2.7",
         "@types/node": "^22.10.6",
+        "eslint": "^9.22.0",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
         "vitest": "^3.0.8"
@@ -13214,6 +13753,72 @@
       "peerDependencies": {
         "@openfga/sdk": "^0.8.0"
       }
+    },
+    "packages/ai-llamaindex/node_modules/@eslint/compat": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.7.tgz",
+      "integrity": "sha512-xvv7hJE32yhegJ8xNAnb62ggiAwTYHBpUCWhRxEj/ksvgDJuSXfoDkBcRYaYNFiJ+jH0IE3K16hd+xXzhBgNbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.10.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-llamaindex/node_modules/@eslint/eslintrc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-llamaindex/node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/ai-llamaindex/node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/ai-llamaindex/node_modules/@llamaindex/cloud": {
       "version": "3.0.9",
@@ -13295,6 +13900,179 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "packages/ai-llamaindex/node_modules/eslint": {
+      "version": "9.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.22.0.tgz",
+      "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.1.0",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.22.0",
+        "@eslint/plugin-kit": "^0.2.7",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-llamaindex/node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-llamaindex/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-llamaindex/node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/ai-llamaindex/node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/ai-llamaindex/node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-llamaindex/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "packages/ai-llamaindex/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/ai-llamaindex/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/ai-llamaindex/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
@@ -13344,8 +14122,10 @@
         "z": "1.0.1"
       },
       "devDependencies": {
+        "@eslint/compat": "^1.2.7",
         "@types/node": "^22.10.6",
         "@types/react": "^19.0.10",
+        "eslint": "^9.22.0",
         "tsup": "^8.3.6",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
@@ -13380,6 +14160,48 @@
         }
       }
     },
+    "packages/ai-vercel/node_modules/@eslint/compat": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.7.tgz",
+      "integrity": "sha512-xvv7hJE32yhegJ8xNAnb62ggiAwTYHBpUCWhRxEj/ksvgDJuSXfoDkBcRYaYNFiJ+jH0IE3K16hd+xXzhBgNbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.10.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-vercel/node_modules/@eslint/eslintrc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "packages/ai-vercel/node_modules/ai": {
       "version": "4.1.54",
       "license": "Apache-2.0",
@@ -13405,6 +14227,155 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "packages/ai-vercel/node_modules/eslint": {
+      "version": "9.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.22.0.tgz",
+      "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.1.0",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.22.0",
+        "@eslint/plugin-kit": "^0.2.7",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ai-vercel/node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-vercel/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-vercel/node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/ai-vercel/node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "packages/ai-vercel/node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/ai-vercel/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/ai-vercel/node_modules/z": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "lint": "turbo run lint"
   },
   "devDependencies": {
     "turbo": "^2.3.4"

--- a/packages/ai-genkit/package.json
+++ b/packages/ai-genkit/package.json
@@ -12,7 +12,7 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "clean": "rm -rf dist",
-    "lint": "eslint \"./**/*.ts*\"",
+    "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "test": "vitest run"
   },
@@ -39,6 +39,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.6",
+    "@eslint/compat": "^1.2.7",
+    "eslint": "^9.22.0",
     "tsup": "^8.3.6",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",

--- a/packages/ai-genkit/test/index.test.ts
+++ b/packages/ai-genkit/test/index.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
-import { genkit, Document } from "genkit";
-import { FGAReranker, auth0 } from "../src/retrievers/fga-reranker";
+import { Document, genkit } from "genkit";
+import { describe, expect, it, vi } from "vitest";
 
 import {
-  OpenFgaClient,
-  CredentialsMethod,
   ConsistencyPreference,
+  CredentialsMethod,
+  OpenFgaClient,
 } from "@openfga/sdk";
+
+import { auth0, FGAReranker } from "../src/retrievers/fga-reranker";
 
 describe("FGAReranker", async () => {
   process.env.FGA_CLIENT_ID = "client-id";
@@ -59,7 +60,6 @@ describe("FGAReranker", async () => {
   });
 
   it("should filter relevant documents based on permission", async () => {
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {
@@ -102,7 +102,6 @@ describe("FGAReranker", async () => {
   });
 
   it("should handle empty permission list", async () => {
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({ result: [] });
 
     const rankedDocuments = await ai.rerank({
@@ -121,7 +120,6 @@ describe("FGAReranker", async () => {
       Document.fromText("private content", { id: "public-doc" }),
     ];
 
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {
@@ -165,7 +163,6 @@ describe("FGAReranker", async () => {
   });
 
   it("should handle all documents being filtered out", async () => {
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {
@@ -197,7 +194,6 @@ describe("FGAReranker", async () => {
   });
 
   it("should handle batchCheck error gracefully", async () => {
-    // @ts-ignore
     mockClient.batchCheck = vi
       .fn()
       .mockRejectedValue(new Error("FGA API Error"));
@@ -223,7 +219,6 @@ describe("FGAReranker", async () => {
       }),
     ];
 
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {

--- a/packages/ai-langchain/eslint.config.mjs
+++ b/packages/ai-langchain/eslint.config.mjs
@@ -11,7 +11,6 @@ export default [
   includeIgnoreFile(gitIgnore),
   { files: [
     "src/*.{js,mjs,cjs,ts}",
-    "test/*.{js,mjs,cjs,ts}",
   ] },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,

--- a/packages/ai-langchain/package.json
+++ b/packages/ai-langchain/package.json
@@ -12,7 +12,7 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "clean": "rm -rf dist",
-    "lint": "eslint \"./**/*.ts*\"",
+    "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "test": "vitest run"
   },
@@ -42,7 +42,9 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@eslint/compat": "^1.2.7",
     "@types/node": "^22.10.6",
+    "eslint": "^9.22.0",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
     "vitest": "^3.0.8"

--- a/packages/ai-langchain/src/ciba/ciba-graph/initialize-ciba.ts
+++ b/packages/ai-langchain/src/ciba/ciba-graph/initialize-ciba.ts
@@ -82,6 +82,7 @@ export const initializeCIBA =
       );
 
       const scheduler = cibaParams?.config.scheduler;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
       const onResumeInvoke = cibaParams?.config.onResumeInvoke!;
       const threadId = config?.metadata?.thread_id as string;
       const schedulerParams = {

--- a/packages/ai-langchain/src/retrievers/fga-retriever.ts
+++ b/packages/ai-langchain/src/retrievers/fga-retriever.ts
@@ -1,5 +1,8 @@
+import { z } from "zod";
+
 import { Document, DocumentInterface } from "@langchain/core/documents";
 import { BaseRetriever } from "@langchain/core/retrievers";
+import { StructuredToolInterface, tool } from "@langchain/core/tools";
 import {
   ClientBatchCheckItem,
   ConsistencyPreference,
@@ -9,9 +12,6 @@ import {
 
 import type { BaseRetrieverInput } from "@langchain/core/retrievers";
 import type { CallbackManagerForRetrieverRun } from "@langchain/core/callbacks/manager";
-import { StructuredToolInterface, tool } from "@langchain/core/tools";
-import { z } from "zod";
-
 export type FGARetrieverCheckerFn = (
   doc: DocumentInterface<Record<string, any>>
 ) => ClientBatchCheckItem;
@@ -140,7 +140,7 @@ export class FGARetriever extends BaseRetriever {
     const permissionsMap = await this.checkPermissions(checks);
 
     return documents.filter(
-      (d, i) => permissionsMap.get(documentToObject.get(d) || "") === true
+      (d) => permissionsMap.get(documentToObject.get(d) || "") === true
     );
   }
 
@@ -179,6 +179,7 @@ export class FGARetriever extends BaseRetriever {
    * @returns StructuredToolInterface.
    */
   asJoinedStringTool(): StructuredToolInterface {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const retriever = this;
     return tool(
       async ({ query }) => {

--- a/packages/ai-langchain/test/index.test.ts
+++ b/packages/ai-langchain/test/index.test.ts
@@ -1,12 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
-import { FGARetriever } from "../src/retrievers/fga-retriever";
-import {
-  OpenFgaClient,
-  CredentialsMethod,
-  ConsistencyPreference,
-} from "@openfga/sdk";
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { describe, expect, it, vi } from "vitest";
+
 import { Document } from "@langchain/core/documents";
 import { BaseRetriever } from "@langchain/core/retrievers";
+import {
+  ConsistencyPreference,
+  CredentialsMethod,
+  OpenFgaClient,
+} from "@openfga/sdk";
+
+import { FGARetriever } from "../src/retrievers/fga-retriever";
 
 describe("FGARetriever", () => {
   process.env.FGA_CLIENT_ID = "client-id";
@@ -64,9 +67,8 @@ describe("FGARetriever", () => {
 
   it("should filter documents based on permissions", async () => {
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
+    // @ts-expect-error
     mockRetriever._getRelevantDocuments.mockResolvedValue(mockDocuments);
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {
@@ -94,7 +96,7 @@ describe("FGARetriever", () => {
 
   it("should handle empty document list", async () => {
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
+    // @ts-expect-error
     mockRetriever._getRelevantDocuments.mockResolvedValue([]);
 
     const result = await retriever.invoke("test query");
@@ -103,9 +105,8 @@ describe("FGARetriever", () => {
 
   it("should handle empty permission list", async () => {
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
+    // @ts-expect-error
     mockRetriever._getRelevantDocuments.mockResolvedValue(mockDocuments);
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({ result: [] });
 
     const result = await retriever.invoke("test query");
@@ -126,9 +127,8 @@ describe("FGARetriever", () => {
     ];
 
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
+    // @ts-expect-error
     mockRetriever._getRelevantDocuments.mockResolvedValue(duplicateDocuments);
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {
@@ -166,9 +166,8 @@ describe("FGARetriever", () => {
 
   it("should handle all documents being filtered out", async () => {
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
+    // @ts-expect-error
     mockRetriever._getRelevantDocuments.mockResolvedValue(mockDocuments);
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         { request: { object: "doc:public-doc" }, allowed: false },
@@ -182,9 +181,8 @@ describe("FGARetriever", () => {
 
   it("should return joined string of filtered doc content", async () => {
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
+    // @ts-expect-error
     mockRetriever._getRelevantDocuments.mockResolvedValue(mockDocuments);
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {
@@ -212,7 +210,6 @@ describe("FGARetriever", () => {
   });
 
   it("should handle batchCheck error gracefully", async () => {
-    // @ts-ignore
     mockClient.batchCheck = vi
       .fn()
       .mockRejectedValue(new Error("FGA API Error"));

--- a/packages/ai-llamaindex/eslint.config.mjs
+++ b/packages/ai-llamaindex/eslint.config.mjs
@@ -11,7 +11,6 @@ export default [
   includeIgnoreFile(gitIgnore),
   { files: [
     "src/*.{js,mjs,cjs,ts}",
-    "test/*.{js,mjs,cjs,ts}",
   ] },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,

--- a/packages/ai-llamaindex/package.json
+++ b/packages/ai-llamaindex/package.json
@@ -41,6 +41,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.6",
+    "@eslint/compat": "^1.2.7",
+    "eslint": "^9.22.0",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
     "vitest": "^3.0.8"

--- a/packages/ai-llamaindex/test/index.test.ts
+++ b/packages/ai-llamaindex/test/index.test.ts
@@ -1,14 +1,17 @@
-import { describe, it, expect, vi } from "vitest";
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { BaseRetriever, NodeWithScore } from "llamaindex";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ConsistencyPreference,
+  CredentialsMethod,
+  OpenFgaClient,
+} from "@openfga/sdk";
+
 import {
   FGARetriever,
   FGARetrieverCheckerFn,
 } from "../src/retrievers/fga-retriever";
-import {
-  OpenFgaClient,
-  CredentialsMethod,
-  ConsistencyPreference,
-} from "@openfga/sdk";
-import { BaseRetriever, NodeWithScore } from "llamaindex";
 
 describe("FGARetriever", () => {
   process.env.FGA_CLIENT_ID = "client-id";
@@ -65,7 +68,6 @@ describe("FGARetriever", () => {
   });
 
   it("retrieves and filters nodes based on permissions", async () => {
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {
@@ -94,7 +96,7 @@ describe("FGARetriever", () => {
   });
 
   it("should handle empty document list", async () => {
-    // @ts-ignore
+    // @ts-expect-error
     args.retriever.retrieve.mockResolvedValue([]);
     const retriever = FGARetriever.create(args, mockClient);
 
@@ -104,7 +106,6 @@ describe("FGARetriever", () => {
 
   it("should handle empty permission list", async () => {
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({ result: [] });
 
     const result = await retriever.retrieve({ query: "test" });
@@ -124,11 +125,10 @@ describe("FGARetriever", () => {
       } as unknown as NodeWithScore,
     ];
 
-    // @ts-ignore
+    // @ts-expect-error
     args.retriever.retrieve.mockResolvedValue(duplicateDocuments);
 
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         {
@@ -166,7 +166,6 @@ describe("FGARetriever", () => {
 
   it("should handle all documents being filtered out", async () => {
     const retriever = FGARetriever.create(args, mockClient);
-    // @ts-ignore
     mockClient.batchCheck = vi.fn().mockResolvedValue({
       result: [
         { request: { object: "doc:public-doc" }, allowed: false },
@@ -179,7 +178,6 @@ describe("FGARetriever", () => {
   });
 
   it("should handle batchCheck error gracefully", async () => {
-    // @ts-ignore
     mockClient.batchCheck = vi
       .fn()
       .mockRejectedValue(new Error("FGA API Error"));

--- a/packages/ai-vercel/eslint.config.mjs
+++ b/packages/ai-vercel/eslint.config.mjs
@@ -1,10 +1,18 @@
 import globals from "globals";
 import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
+import path from 'node:path';
+import { includeIgnoreFile } from "@eslint/compat";
+
+const gitIgnore = path.resolve(import.meta.dirname, '../../', ".gitignore");
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  { files: ["dist/*.{js,mjs,cjs,ts}"] },
+  includeIgnoreFile(gitIgnore),
+  { files: [
+    "src/*.{js,mjs,cjs,ts}",
+    "test/*.{js,mjs,cjs,ts}",
+  ] },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,

--- a/packages/ai-vercel/package.json
+++ b/packages/ai-vercel/package.json
@@ -12,7 +12,7 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "clean": "rm -rf dist",
-    "lint": "eslint \"./**/*.ts*\"",
+    "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "test": "vitest run"
   },
@@ -56,8 +56,10 @@
     "react": "^19.0.0"
   },
   "devDependencies": {
+    "@eslint/compat": "^1.2.7",
     "@types/node": "^22.10.6",
     "@types/react": "^19.0.10",
+    "eslint": "^9.22.0",
     "tsup": "^8.3.6",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,11 @@
     "test": {
       "dependsOn": ["^test"]
     },
+    "lint": {
+      "dependsOn": [
+        "^lint"
+      ]
+    },
     "type-check": {
       "dependsOn": ["^build", "build"]
     }


### PR DESCRIPTION
This pull request includes several changes to improve linting configurations, update dependencies, and clean up test files across multiple packages. The most important changes include adding linting steps to CI workflows, updating `package.json` scripts, and enhancing ESLint configurations.

### CI/CD Improvements:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR35-R46): Added a linting step to the CI workflow to ensure code quality.

### Package Scripts and Dependencies:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R8): Added a `lint` script to run linting across the codebase.
* [`packages/ai-genkit/package.json`](diffhunk://#diff-c6a418b63601c8cd1ebb9280658c36c7afce12b9a7444a40705de54d18c1c983L15-R15): Updated the `lint` script to use a simplified pattern and added `@eslint/compat` and `eslint` as development dependencies. [[1]](diffhunk://#diff-c6a418b63601c8cd1ebb9280658c36c7afce12b9a7444a40705de54d18c1c983L15-R15) [[2]](diffhunk://#diff-c6a418b63601c8cd1ebb9280658c36c7afce12b9a7444a40705de54d18c1c983R42-R43)

### ESLint Configuration:
* [`packages/ai-genkit/eslint.config.mjs`](diffhunk://#diff-583489b4c2177a9e163447906c23a1d6ce1cdc6d42df1495ff1ad7b6bbc9194fR4-R15): Imported additional dependencies and included `.gitignore` for ignoring files during linting.
* [`packages/ai-langchain/eslint.config.mjs`](diffhunk://#diff-784a2069789c2a3c67d6513fbe9f6d9ca20a52f74668ecb273bebb5c23b1d12dR1-R23): Added a comprehensive ESLint configuration including globals, plugins, and custom rules.
* [`packages/ai-llamaindex/eslint.config.mjs`](diffhunk://#diff-784a2069789c2a3c67d6513fbe9f6d9ca20a52f74668ecb273bebb5c23b1d12dR1-R23): Similar to `ai-langchain`, added a detailed ESLint configuration.

### Test File Cleanup:
* [`packages/ai-genkit/test/index.test.ts`](diffhunk://#diff-63fa15b77e44bacc0058e6a2b7a195d41bd4e0241c9623d9038c5c21dac55a33L1-R11): Removed unnecessary `@ts-ignore` comments and improved import order. [[1]](diffhunk://#diff-63fa15b77e44bacc0058e6a2b7a195d41bd4e0241c9623d9038c5c21dac55a33L1-R11) [[2]](diffhunk://#diff-63fa15b77e44bacc0058e6a2b7a195d41bd4e0241c9623d9038c5c21dac55a33L62) [[3]](diffhunk://#diff-63fa15b77e44bacc0058e6a2b7a195d41bd4e0241c9623d9038c5c21dac55a33L105) [[4]](diffhunk://#diff-63fa15b77e44bacc0058e6a2b7a195d41bd4e0241c9623d9038c5c21dac55a33L124) [[5]](diffhunk://#diff-63fa15b77e44bacc0058e6a2b7a195d41bd4e0241c9623d9038c5c21dac55a33L168) [[6]](diffhunk://#diff-63fa15b77e44bacc0058e6a2b7a195d41bd4e0241c9623d9038c5c21dac55a33L200) [[7]](diffhunk://#diff-63fa15b77e44bacc0058e6a2b7a195d41bd4e0241c9623d9038c5c21dac55a33L226)
* [`packages/ai-langchain/test/index.test.ts`](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL1-R12): Replaced `@ts-ignore` comments with `@ts-expect-error` for better type checking. [[1]](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL1-R12) [[2]](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL67-L69) [[3]](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL97-R99) [[4]](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL106-L108) [[5]](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL129-L131) [[6]](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL169-L171) [[7]](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL185-L187) [[8]](diffhunk://#diff-c9d3c28a2f378aa4080f79ee816d07941987600e2e9f9990850d5f989b3d138cL215)
* [`packages/ai-llamaindex/test/index.test.ts`](diffhunk://#diff-0b82b7f17a97f7506671d16cb69abb489f1c6a5fc748e26d5b1c9f662cff6442L1-L11): Improved import statements and replaced `@ts-ignore` with `@ts-expect-error`. [[1]](diffhunk://#diff-0b82b7f17a97f7506671d16cb69abb489f1c6a5fc748e26d5b1c9f662cff6442L1-L11) [[2]](diffhunk://#diff-0b82b7f17a97f7506671d16cb69abb489f1c6a5fc748e26d5b1c9f662cff6442L68) [[3]](diffhunk://#diff-0b82b7f17a97f7506671d16cb69abb489f1c6a5fc748e26d5b1c9f662cff6442L97-R99) [[4]](diffhunk://#diff-0b82b7f17a97f7506671d16cb69abb489f1c6a5fc748e26d5b1c9f662cff6442L107)