### PR TITLE
chore: add accessToken to federated connection authorizer

### DIFF
--- a/packages/ai/test/federated-connection-base.test.ts
+++ b/packages/ai/test/federated-connection-base.test.ts
@@ -44,6 +44,29 @@ describe("FederatedConnectionAuthorizerBase", () => {
       );
       expect(auth).toBeInstanceOf(FederatedConnectionAuthorizerBase<[string]>);
     });
+    it("should initialize with custom getAccessToken func", () => {
+      const auth = new FederatedConnectionAuthorizerBase<[string]>(
+        {
+          domain: "custom.auth0.com",
+          clientId: "custom-client",
+          clientSecret: "custom-secret",
+        },
+        {
+          accessToken: () => {
+            return {
+              access_token: "test",
+              id_token: "test",
+              scope: "read:calendar",
+              expires_in: 3600,
+              token_type: "Bearer",
+            };
+          },
+          connection: "google",
+          scopes: ["read:calendar"],
+        }
+      );
+      expect(auth).toBeInstanceOf(FederatedConnectionAuthorizerBase<[string]>);
+    });
   });
 
   /**


### PR DESCRIPTION
This pull request includes several updates to improve code formatting, add new dependencies, and enhance the functionality of the `FederatedConnectionAuthorizerBase` class. The most important changes include adding new dependencies to `package.json`, updating ESLint configurations, and improving the handling of access tokens in the `FederatedConnectionAuthorizerBase` class.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R14-R16): Added `eslint-config-prettier` and `prettier` to `devDependencies`.
* [`packages/ai/package.json`](diffhunk://#diff-3758ea4fd63e4789bf712baab7b4b0227fce843a17e2ed535091b9c3b83ff2dfL48-R50): Replaced `@eslint/js` with `@eslint/compat` and updated `eslint` to version 9.22.0.

### ESLint Configuration:
* [`packages/ai/eslint.config.mjs`](diffhunk://#diff-c2d61549af1c325ce78fa3fef07316a7834f0a724f130d17596631bbd1452820R4-R15): Included `.gitignore` file in ESLint configuration and updated file patterns for linting.

### Federated Connection Authorizer Enhancements:
* [`packages/ai/src/authorizers/federated-connections/index.ts`](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L10-R14): Added optional `getAccessToken` parameter and validation logic to ensure either `refreshToken` or `getAccessToken` is provided, but not both. [[1]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L10-R14) [[2]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L28-R48)
* [`packages/ai/src/authorizers/federated-connections/index.ts`](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L62-R86): Refactored `getAccessToken` method to use `getAccessTokenImpl` and validate token responses. [[1]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L62-R86) [[2]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L96-R130) [[3]](diffhunk://#diff-06f1cf203d75da3f5ad02ab6af6931b0be1511bf01b31c400498ebae207bc2b7L127)

### Testing:
* [`packages/ai/test/federated-connection-base.test.ts`](diffhunk://#diff-b0b5fcd45b46920ce9e9cfed1ec0c18245053e9842542ea2683f12a3860594d8R44-R66): Added a test case for initializing `FederatedConnectionAuthorizerBase` with a custom `getAccessToken` function.