### PR TITLE
chore: rename FCAT entry points to TokenForConnection

### DIFF
--- a/demos/nextjs-ai/lib/ai/tools/check-user-calendar.ts
+++ b/demos/nextjs-ai/lib/ai/tools/check-user-calendar.ts
@@ -2,13 +2,13 @@ import { tool } from "ai";
 import { addHours } from "date-fns";
 import { z } from "zod";
 
-import { withCalendarFreeBusyAccess } from "@/lib/auth0-ai";
+import { withTokenForConnection } from "@/lib/auth0-ai";
 import {
   FederatedConnectionError,
-  getFederatedConnectionAccessToken,
+  getAccessTokenForConnection,
 } from "@auth0/ai-vercel";
 
-export const checkUsersCalendar = withCalendarFreeBusyAccess(
+export const checkUsersCalendar = withTokenForConnection(
   tool({
     description:
       "Check user availability on a given date time on their calendar",
@@ -16,7 +16,7 @@ export const checkUsersCalendar = withCalendarFreeBusyAccess(
       date: z.coerce.date(),
     }),
     execute: async ({ date }) => {
-      const accessToken = getFederatedConnectionAccessToken();
+      const accessToken = getAccessTokenForConnection();
       const url = "https://www.googleapis.com/calendar/v3/freeBusy";
       const body = JSON.stringify({
         timeMin: date,

--- a/demos/nextjs-ai/lib/auth0-ai.ts
+++ b/demos/nextjs-ai/lib/auth0-ai.ts
@@ -4,7 +4,7 @@ import { auth0 } from "./auth0";
 
 const auth0AI = new Auth0AI();
 
-export const withCalendarFreeBusyAccess = auth0AI.withFederatedConnection({
+export const withTokenForConnection = auth0AI.withTokenForConnection({
   refreshToken: async () => {
     const session = await auth0.getSession();
     const refreshToken = session?.tokenSet.refreshToken as string;

--- a/packages/ai-vercel/README.md
+++ b/packages/ai-vercel/README.md
@@ -4,8 +4,7 @@
 
 ## Install
 
-> [!WARNING]
-> `@auth0/ai-vercel` is currently under development and it is not intended to be used in production, and therefore has no official support.
+> [!WARNING] > `@auth0/ai-vercel` is currently under development and it is not intended to be used in production, and therefore has no official support.
 
 ```
 $ npm install @auth0/ai-vercel
@@ -38,7 +37,7 @@ First initialize the Federated Connection Authorizer as follows:
 ```javascript
 import { auth0 } from "./auth0";
 
-export const withCalendarFreeBusyAccess = auth0AI.withFederatedConnection({
+export const withTokenForConnection = auth0AI.withTokenForConnection({
   // A function to retrieve the refresh token of the context.
   refreshToken: async () => {
     const session = await auth0.getSession();
@@ -52,15 +51,15 @@ export const withCalendarFreeBusyAccess = auth0AI.withFederatedConnection({
 });
 ```
 
-Then use the `withCalendarFreeBusyAccess` to wrap the tool and use `getFederatedConnectionAccessToken` from the SDK to get the access token.
+Then use the `withTokenForConnection` to wrap the tool and use `getAccessTokenForConnection` from the SDK to get the access token.
 
 ```javascript
 import {
   FederatedConnectionError,
-  getFederatedConnectionAccessToken,
+  getAccessTokenForConnection,
 } from "@auth0/ai-vercel";
 
-export const checkUsersCalendar = withCalendarFreeBusyAccess(
+export const checkUsersCalendar = withTokenForConnection(
   tool({
     description:
       "Check user availability on a given date time on their calendar",
@@ -68,7 +67,7 @@ export const checkUsersCalendar = withCalendarFreeBusyAccess(
       date: z.coerce.date(),
     }),
     execute: async ({ date }) => {
-      const accessToken = getFederatedConnectionAccessToken();
+      const accessToken = getAccessTokenForConnection();
       const url = "https://www.googleapis.com/calendar/v3/freeBusy";
       const body = JSON.stringify({
         timeMin: date,
@@ -265,4 +264,3 @@ Please do not report security vulnerabilities on the public GitHub issue tracker
 <p align="center">Auth0 is an easy to implement, adaptable authentication and authorization platform. To learn more checkout <a href="https://auth0.com/why-auth0">Why Auth0?</a></p>
 <p align="center">
 This project is licensed under the Apache 2.0 license. See the <a href="/LICENSE"> LICENSE</a> file for more info.</p>
-

--- a/packages/ai-vercel/src/Auth0AI.ts
+++ b/packages/ai-vercel/src/Auth0AI.ts
@@ -58,11 +58,11 @@ export class Auth0AI {
     return authorizer;
   }
 
-  withFederatedConnection(params: FederatedConnectionParams): ToolWrapper;
+  withTokenForConnection(params: FederatedConnectionParams): ToolWrapper;
 
-  withFederatedConnection(params: FederatedConnectionParams, tool: Tool): Tool;
+  withTokenForConnection(params: FederatedConnectionParams, tool: Tool): Tool;
 
-  withFederatedConnection(params: FederatedConnectionParams, tool?: Tool) {
+  withTokenForConnection(params: FederatedConnectionParams, tool?: Tool) {
     const fc = new FederatedConnectionAuthorizer(this, params);
     const authorizer = fc.authorizer();
     if (tool) {

--- a/packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts
+++ b/packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts
@@ -1,10 +1,10 @@
 import { asyncLocalStorage } from "@auth0/ai/FederatedConnections";
 
-export const getFederatedConnectionAccessToken = () => {
+export const getAccessTokenForConnection = () => {
   const t = asyncLocalStorage.getStore();
   if (typeof t === "undefined") {
     throw new Error(
-      "The tool must be wrapped with the withFederatedConnection function."
+      "The tool must be wrapped with the withTokenForConnection function."
     );
   }
   return t.accessToken;

--- a/packages/ai-vercel/src/FederatedConnections/index.ts
+++ b/packages/ai-vercel/src/FederatedConnections/index.ts
@@ -1,3 +1,3 @@
-export { FederatedConnectionAuthorizer } from './FederatedConnectionAuthorizer';
-export { FederatedConnectionError } from './FederatedConnectionError';
-export { getFederatedConnectionAccessToken } from './getFederatedConnectionAccessToken';
+export { FederatedConnectionAuthorizer } from "./FederatedConnectionAuthorizer";
+export { FederatedConnectionError } from "./FederatedConnectionError";
+export { getAccessTokenForConnection } from "./getAccessTokenForConnection";

--- a/packages/ai-vercel/src/index.ts
+++ b/packages/ai-vercel/src/index.ts
@@ -3,6 +3,6 @@ export { Auth0AI } from "./Auth0AI";
 export { getCIBACredentials } from "./CIBA";
 
 export {
-  getFederatedConnectionAccessToken,
+  getAccessTokenForConnection,
   FederatedConnectionError,
 } from "./FederatedConnections";

--- a/packages/ai-vercel/test/FerderatedConnectionAuthorizer.test.ts
+++ b/packages/ai-vercel/test/FerderatedConnectionAuthorizer.test.ts
@@ -9,7 +9,7 @@ import { FederatedConnectionAuthorizerBase } from "@auth0/ai/FederatedConnection
 import {
   FederatedConnectionAuthorizer,
   FederatedConnectionError,
-  getFederatedConnectionAccessToken,
+  getAccessTokenForConnection,
 } from "../src/FederatedConnections";
 
 describe("FederatedConnectionAuthorizer", () => {
@@ -95,7 +95,7 @@ describe("FederatedConnectionAuthorizer", () => {
 
       try {
         mockTool.execute.mockImplementation(() => {
-          accessToken = getFederatedConnectionAccessToken();
+          accessToken = getAccessTokenForConnection();
           return { result: "success" };
         });
         await protectedTool!.execute!(


### PR DESCRIPTION
This pull request includes significant refactoring and renaming changes to improve the consistency and clarity of the codebase, particularly around the handling of federated connections and access tokens. The most important changes include renaming functions and variables related to federated connections, updating the documentation to reflect these changes, and making corresponding updates in the test files.

Renaming functions and variables:

* [`demos/nextjs-ai/lib/ai/tools/check-user-calendar.ts`](diffhunk://#diff-f3f2d3be3b9f4878ba0fd03f343151d896dd4106974670fa4f6c3085cc431101L5-R19): Renamed `withCalendarFreeBusyAccess` to `withTokenForConnection` and `getFederatedConnectionAccessToken` to `getAccessTokenForConnection`.
* [`demos/nextjs-ai/lib/auth0-ai.ts`](diffhunk://#diff-dd1bdd6b73133875f3aea6238b144a18bafdfb22510d962545876e35f24c6d1eL7-R7): Renamed `withCalendarFreeBusyAccess` to `withTokenForConnection`.
* [`packages/ai-vercel/src/Auth0AI.ts`](diffhunk://#diff-d5d9b6e61e338fbeeb2ca081e2eb349d8d1c0b5aec7565b4c44344e65dcea8a0L61-R65): Renamed `withFederatedConnection` to `withTokenForConnection`.
* [`packages/ai-vercel/src/FederatedConnections/getFederatedConnectionAccessToken.ts`](diffhunk://#diff-9ba234cadbc52942b8488636caf5ab40e505f907932b0ffdbd80de1978a9e26cL3-R7): Renamed `getFederatedConnectionAccessToken` to `getAccessTokenForConnection`.
* [`packages/ai-vercel/src/FederatedConnections/index.ts`](diffhunk://#diff-da4b2398af3db4e2bc86a356276e35b1342f4d9b97719f26effa58fa19d023beL1-R3): Updated exports to reflect the renaming of `getFederatedConnectionAccessToken` to `getAccessTokenForConnection`.

Documentation updates:

* [`packages/ai-vercel/README.md`](diffhunk://#diff-6c7b20f5b315d5227899a28d3b17d1fd20266b33e2bb028eb4be0708458a79aeL7-R7): Updated references to `withFederatedConnection` and `getFederatedConnectionAccessToken` to `withTokenForConnection` and `getAccessTokenForConnection`. [[1]](diffhunk://#diff-6c7b20f5b315d5227899a28d3b17d1fd20266b33e2bb028eb4be0708458a79aeL7-R7) [[2]](diffhunk://#diff-6c7b20f5b315d5227899a28d3b17d1fd20266b33e2bb028eb4be0708458a79aeL41-R40) [[3]](diffhunk://#diff-6c7b20f5b315d5227899a28d3b17d1fd20266b33e2bb028eb4be0708458a79aeL55-R70)

Test file updates:

* [`packages/ai-vercel/test/FerderatedConnectionAuthorizer.test.ts`](diffhunk://#diff-798cc1cdf0624f504f0c596491a6eeaa9b112ef33bc352f0088466373c931bd8L12-R12): Updated test cases to use `getAccessTokenForConnection` instead of `getFederatedConnectionAccessToken`. [[1]](diffhunk://#diff-798cc1cdf0624f504f0c596491a6eeaa9b112ef33bc352f0088466373c931bd8L12-R12) [[2]](diffhunk://#diff-798cc1cdf0624f504f0c596491a6eeaa9b112ef33bc352f0088466373c931bd8L98-R98)