### PR TITLE
chore(docs): add calling-apis examples folder and diagrams

### DIFF
--- a/examples/async-user-confirmation/README.md
+++ b/examples/async-user-confirmation/README.md
@@ -12,6 +12,24 @@ Async User Confirmation enables background agents to perform tasks that require 
 
 This process ensures that users maintain control over significant actions initiated by automated agents.
 
+### Diagram
+
+Below is a high-level workflow:
+
+<p align="center">
+  <img
+    style="margin-left: auto; margin-right: auto; padding: 10px; background: #4a4a4a; border-radius: 10px; max-height: 500px;"
+    src="https://cdn.auth0.com/website/auth0-lab/ai/sdks/diagrams/async-user-confirmation-enroll.png"
+  />
+<p>
+
+<p align="center">
+  <img
+    style="margin-left: auto; margin-right: auto; padding: 10px; background: #4a4a4a; border-radius: 10px; max-height: 500px;"
+    src="https://cdn.auth0.com/website/auth0-lab/ai/sdks/diagrams/async-user-confirmation-authorize.png"
+  />
+<p>
+
 ### Examples
 
 Explore the following examples demonstrating the integration of **Auth0's Async User confirmation** with **LangChain**, **LlamaIndex**, **Genkit**, and others:

--- a/examples/authorization-for-rag/README.md
+++ b/examples/authorization-for-rag/README.md
@@ -14,7 +14,10 @@ Authorization for RAG ensure that users can only access documents they are permi
 Below is a high-level workflow:
 
 <p align="center">
-    <img style="margin-left: auto; margin-right: auto;" height="700px" src="https://images.ctfassets.net/23aumh6u8s0i/76DegvQtjEx5jNDcqvy1VD/462977639c07dd1d92e82783d66aac7e/rag-with-fga-flow.png" />
+  <img
+    style="margin-left: auto; margin-right: auto; padding: 10px; background: #4a4a4a; border-radius: 10px; max-height: 500px;"
+    src="https://cdn.auth0.com/website/auth0-lab/ai/sdks/diagrams/authorization-for-rag.png"
+  />
 <p>
 
 ### Examples

--- a/examples/calling-apis/README.md
+++ b/examples/calling-apis/README.md
@@ -1,0 +1,30 @@
+## Calling APIs on user's behalf
+
+Calling APIs on user's behalf allows you to use secure standards to call APIs from tools, integrating your app with other products. These examples demonstrate how to integrate **Auth0 AI SDK** with **AI SDK**, **LangChain**, **LlamaIndex**, **Genkit** and others to call APIs on behalf of users. For more information, refer to the [documentation](https://demo.auth0.ai/docs/call-apis-on-users-behalf).
+
+### How It Works
+
+1. **User Request**: A user submits a request to execute a tool that requires calling an external API.
+2. **Permissions check**: Auth0 AI SDK verifies the user's permissions and checks the external API authorization requirements.
+3. **Response Generation**: Base on the required permissions, the system generates a response tailored to request users's explicit authorization.
+4. **User Authorization**: The user reviews the request and provides consent if they choose to proceed.
+5. **Token Generation**: The system generates a token for the user to access the external API.
+6. **API Call**: The system calls the external API on behalf of the user, using the tool parameters from the User's original request.
+7. **Tool Execution**: The system executes the tool, incorporating the API response into the final output.
+8. **User Response**: The user receives the final output, which may include information retrieved from the external API.
+
+### Diagram
+
+Below is a high-level workflow:
+
+<p align="center">
+  <img
+    style="margin-left: auto; margin-right: auto; padding: 10px; background: #4a4a4a; border-radius: 10px; max-height: 500px;"
+    src="https://cdn.auth0.com/website/auth0-lab/ai/sdks/diagrams/calling-apis-on-user-behalf.png"
+  />
+<p>
+
+### Examples
+
+> [!NOTE]
+> Coming soon...


### PR DESCRIPTION
This pull request includes updates to the documentation for various examples in the Auth0 AI SDK. The changes primarily involve adding diagrams and explanations to improve clarity and understanding.

Key updates to the documentation:

* [`examples/async-user-confirmation/README.md`](diffhunk://#diff-8254fc62a007a6a24ead6df7398765329238da392eafbe127123b122faf4eeebR15-R32): Added a high-level workflow diagram for Async User Confirmation.
* [`examples/authorization-for-rag/README.md`](diffhunk://#diff-26bc98b91d933bf6892d97da85c7fef009b818030b3e9a9d995e03c8c662e610L17-R20): Updated the existing diagram with a new image and added styling for better visual presentation.
* [`examples/calling-apis/README.md`](diffhunk://#diff-3e8ba4fae20cf9fd511889810d9d83e80a4391f3ca9f6c8a6b5a854b999f6376R1-R30): Introduced a new section explaining how to call APIs on the user's behalf, including a detailed step-by-step process and a high-level workflow diagram.