### PR TITLE
chore: refactor interrupts

### DIFF
--- a/demos/nextjs-ai/components/chat.tsx
+++ b/demos/nextjs-ai/components/chat.tsx
@@ -5,10 +5,7 @@ import cx from "classnames";
 import { generateUUID } from "@/lib/utils";
 import { useChat } from "@ai-sdk/react";
 import { useInterruptions } from "@auth0/ai-vercel/react";
-import {
-  Auth0Interrupt,
-  FederatedConnectionInterrupt,
-} from "@auth0/ai/interrupts";
+import { FederatedConnectionInterrupt } from "@auth0/ai/interrupts";
 
 import { EnsureAPIAccessPopup } from "./auth0-ai/FederatedConnections/popup";
 import { GoogleCalendarIcon } from "./icons";
@@ -42,10 +39,7 @@ export default function Chat() {
                   const { toolName, toolCallId, state } = toolInvocation;
                   if (
                     state === "call" &&
-                    Auth0Interrupt.is(
-                      FederatedConnectionInterrupt,
-                      toolInterrupt
-                    )
+                    FederatedConnectionInterrupt.isInterrupt(toolInterrupt)
                   ) {
                     return (
                       <EnsureAPIAccessPopup

--- a/demos/nextjs-ai/components/langgraph/chat.tsx
+++ b/demos/nextjs-ai/components/langgraph/chat.tsx
@@ -3,10 +3,7 @@
 import { useQueryState } from "nuqs";
 import { FormEventHandler, useEffect, useRef, useState } from "react";
 
-import {
-  Auth0Interrupt,
-  FederatedConnectionInterrupt,
-} from "@auth0/ai/interrupts";
+import { FederatedConnectionInterrupt } from "@auth0/ai/interrupts";
 import { useStream } from "@langchain/langgraph-sdk/react";
 
 import { EnsureAPIAccessPopup } from "../auth0-ai/FederatedConnections/popup";
@@ -15,7 +12,10 @@ import { GoogleCalendarIcon } from "../icons";
 const useFocus = () => {
   const htmlElRef = useRef<HTMLInputElement>(null);
   const setFocus = () => {
-    htmlElRef.current && htmlElRef.current.focus();
+    if (!htmlElRef.current) {
+      return;
+    }
+    htmlElRef.current.focus();
   };
   return [htmlElRef, setFocus] as const;
 };
@@ -41,7 +41,7 @@ export default function Chat() {
       return;
     }
     setInputFocus();
-  }, [thread.isLoading]);
+  }, [thread.isLoading, setInputFocus]);
 
   // //When the user submits a message, add it to the list of messages and resume the conversation.
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
@@ -72,10 +72,7 @@ export default function Chat() {
         ))}
 
       {thread.interrupt &&
-      Auth0Interrupt.is(
-        FederatedConnectionInterrupt,
-        thread.interrupt.value
-      ) ? (
+      FederatedConnectionInterrupt.isInterrupt(thread.interrupt.value) ? (
         <div
           key={thread.interrupt.ns?.join("")}
           className="whitespace-pre-wrap"

--- a/demos/vercel-ai-agent/src/worker/handlers/conditional_trade.ts
+++ b/demos/vercel-ai-agent/src/worker/handlers/conditional_trade.ts
@@ -10,8 +10,8 @@ import { openai } from "@ai-sdk/openai";
 import { appendToolCall, invokeTools } from "@auth0/ai-vercel/interrupts";
 import {
   Auth0Interrupt,
-  AuthorizationPending,
-  AuthorizationPollingError,
+  AuthorizationPendingInterrupt,
+  AuthorizationPollingInterrupt,
 } from "@auth0/ai/interrupts";
 
 import { ConditionalTrade } from "../../ConditionalTrade";
@@ -84,8 +84,7 @@ export const conditionalTrade = async (
   } catch (err) {
     if (
       err instanceof ToolExecutionError &&
-      err.cause &&
-      err.cause instanceof Auth0Interrupt
+      Auth0Interrupt.isInterrupt(err.cause)
     ) {
       console.log("Handling tool execution error");
       const newMessages = appendToolCall(messages, err);
@@ -94,13 +93,13 @@ export const conditionalTrade = async (
         messages: newMessages,
       });
 
-      const authorizationPending =
-        err.cause instanceof AuthorizationPending ||
-        err.cause instanceof AuthorizationPollingError;
+      const authorizationPendingInterAuthorizationPendingInterrupt =
+        AuthorizationPendingInterrupt.isInterrupt(err.cause) ||
+        AuthorizationPollingInterrupt.isInterrupt(err.cause);
 
       console.log(err.cause.message);
 
-      if (!authorizationPending) {
+      if (!authorizationPendingInterAuthorizationPendingInterrupt) {
         console.log("Authorization is not pending, do not retry.");
         return;
       }

--- a/packages/ai-vercel/src/interrupts/errorSerializer.ts
+++ b/packages/ai-vercel/src/interrupts/errorSerializer.ts
@@ -20,7 +20,7 @@ export const errorSerializer = (errHandler?: errorHandler): errorHandler => {
     if (
       !(error instanceof ToolExecutionError) ||
       error.cause ||
-      !Auth0Interrupt.isInterrupt(error.cause)
+      !(error.cause instanceof Auth0Interrupt)
     ) {
       if (errHandler) {
         return errHandler(error);

--- a/packages/ai-vercel/test/CIBAAuthorizer.test.ts
+++ b/packages/ai-vercel/test/CIBAAuthorizer.test.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 
 import { CIBAAuthorizerBase } from "@auth0/ai/CIBA";
 import {
-  AuthorizationPending,
-  AuthorizationRequestExpiredError,
+  AuthorizationPendingInterrupt,
+  AuthorizationRequestExpiredInterrupt,
   CIBAInterrupt,
 } from "@auth0/ai/interrupts";
 
@@ -63,7 +63,7 @@ describe("CIBAAuthorizer", () => {
         //@ts-ignore
         "getCredentials"
       ).mockImplementation(() => {
-        throw new AuthorizationPending("Authorization pending");
+        throw new AuthorizationPendingInterrupt("Authorization pending");
       });
 
       try {
@@ -97,7 +97,7 @@ describe("CIBAAuthorizer", () => {
         //@ts-ignore
         "getCredentials"
       ).mockImplementation(() => {
-        throw new AuthorizationRequestExpiredError("Authorization pending");
+        throw new AuthorizationRequestExpiredInterrupt("Authorization pending");
       });
 
       try {

--- a/packages/ai/src/authorizers/ciba/index.ts
+++ b/packages/ai/src/authorizers/ciba/index.ts
@@ -4,11 +4,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { AuthorizerParams } from "../";
 import { Credentials } from "../../credentials";
 import {
-  AccessDeniedError,
-  AuthorizationPending,
-  AuthorizationPollingError,
-  AuthorizationRequestExpiredError,
-  UserDoesNotHavePushNotificationsError,
+  AccessDeniedInterrupt,
+  AuthorizationPendingInterrupt,
+  AuthorizationPollingInterrupt,
+  AuthorizationRequestExpiredInterrupt,
+  UserDoesNotHavePushNotificationsInterrupt,
 } from "../../interrupts";
 import { AuthorizerToolParameter, resolveParameter } from "../../parameters";
 
@@ -127,7 +127,7 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
       const elapsedSeconds = Date.now() / 1000 - params.requestedAt;
 
       if (elapsedSeconds >= params.expiresIn) {
-        throw new AuthorizationRequestExpiredError(
+        throw new AuthorizationRequestExpiredInterrupt(
           "Authorization request has expired"
         );
       }
@@ -146,18 +146,20 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
       return credentials;
     } catch (e: any) {
       if (e.error == "invalid_request") {
-        throw new UserDoesNotHavePushNotificationsError(e.error_description);
+        throw new UserDoesNotHavePushNotificationsInterrupt(
+          e.error_description
+        );
       }
       if (e.error == "access_denied") {
-        throw new AccessDeniedError(e.error_description);
+        throw new AccessDeniedInterrupt(e.error_description);
       }
 
       if (e.error === "authorization_pending") {
-        throw new AuthorizationPending(e.error_description);
+        throw new AuthorizationPendingInterrupt(e.error_description);
       }
 
       if (e.error === "slow_down") {
-        throw new AuthorizationPollingError(e.error_description);
+        throw new AuthorizationPollingInterrupt(e.error_description);
       }
 
       throw e;

--- a/packages/ai/src/authorizers/fga/index.ts
+++ b/packages/ai/src/authorizers/fga/index.ts
@@ -6,6 +6,8 @@ import {
 
 import { buildOpenFgaClient, FGAClientParams } from "./fga-client";
 
+export type { FGAClientParams };
+
 export type FGAAuthorizerOptions<ToolExecuteArgs extends any[]> = {
   buildQuery: (...args: ToolExecuteArgs) => Promise<ClientCheckRequest>;
   onUnauthorized?: (...args: ToolExecuteArgs) => any;

--- a/packages/ai/src/interrupts/CIBAInterrupts.ts
+++ b/packages/ai/src/interrupts/CIBAInterrupts.ts
@@ -1,43 +1,60 @@
-import { Auth0Interrupt } from "./Auth0Interrupt";
+import { Auth0Interrupt, Auth0InterruptData } from "./Auth0Interrupt";
 
 export class CIBAInterrupt extends Auth0Interrupt {
   constructor(message: string, code: string) {
-    super(message, `CIBA_${code}`);
+    super(message, code);
+  }
+
+  static isInterrupt<T extends abstract new (...args: any) => any>(
+    this: T,
+    interrupt: any
+  ): interrupt is Auth0InterruptData<InstanceType<T>> {
+    return (
+      Auth0Interrupt.isInterrupt(interrupt) &&
+      interrupt.code.startsWith("CIBA_")
+    );
   }
 }
 
-export class AccessDeniedError extends CIBAInterrupt {
+export class AccessDeniedInterrupt extends CIBAInterrupt {
+  public static code: string = "CIBA_ACCESS_DENIED" as const;
   constructor(message: string) {
-    super(message, "ACCESS_DENIED");
+    super(message, AccessDeniedInterrupt.code);
   }
 }
 
-export class UserDoesNotHavePushNotificationsError extends CIBAInterrupt {
+export class UserDoesNotHavePushNotificationsInterrupt extends CIBAInterrupt {
+  public static code: string =
+    "CIBA_USER_DOES_NOT_HAVE_PUSH_NOTIFICATIONS" as const;
   constructor(message: string) {
-    super(message, "USER_DOES_NOT_HAVE_PUSH_NOTIFICATIONS");
+    super(message, UserDoesNotHavePushNotificationsInterrupt.code);
   }
 }
 
-export class AuthorizationRequestExpiredError extends CIBAInterrupt {
+export class AuthorizationRequestExpiredInterrupt extends CIBAInterrupt {
+  public static code: string = "CIBA_AUTHORIZATION_REQUEST_EXPIRED" as const;
   constructor(message: string) {
-    super(message, "AUTHORIZATION_REQUEST_EXPIRED");
+    super(message, AuthorizationRequestExpiredInterrupt.code);
   }
 }
 
-export class AuthorizationPending extends CIBAInterrupt {
+export class AuthorizationPendingInterrupt extends CIBAInterrupt {
+  public static code: string = "CIBA_AUTHORIZATION_PENDING" as const;
   constructor(message: string) {
-    super(message, "AUTHORIZATION_PENDING");
+    super(message, AuthorizationPendingInterrupt.code);
   }
 }
 
-export class AuthorizationRequired extends Auth0Interrupt {
+export class AuthorizationRequiredInterrupt extends Auth0Interrupt {
+  public static code: string = "CIBA_AUTHORIZATION_REQUIRED" as const;
   constructor(message: string) {
-    super(message, "AUTHORIZATION_REQUIRED");
+    super(message, AuthorizationRequiredInterrupt.code);
   }
 }
 
-export class AuthorizationPollingError extends Auth0Interrupt {
+export class AuthorizationPollingInterrupt extends Auth0Interrupt {
+  public static code: string = "CIBA_AUTHORIZATION_POLLING_ERROR" as const;
   constructor(message: string) {
-    super(message, "AUTHORIZATION_POLLING_ERROR");
+    super(message, AuthorizationPollingInterrupt.code);
   }
 }

--- a/packages/ai/src/interrupts/FederatedConnectionInterrupt.ts
+++ b/packages/ai/src/interrupts/FederatedConnectionInterrupt.ts
@@ -23,7 +23,7 @@ export class FederatedConnectionInterrupt extends Auth0Interrupt {
    */
   public readonly requiredScopes: string[];
 
-  static code: string = "FEDERATED_CONNECTION_ERROR";
+  public static code = "FEDERATED_CONNECTION_ERROR" as const;
 
   constructor(
     message: string,

--- a/packages/ai/src/interrupts/index.ts
+++ b/packages/ai/src/interrupts/index.ts
@@ -5,10 +5,10 @@ export {
 } from "./FederatedConnectionInterrupt";
 export {
   CIBAInterrupt,
-  AccessDeniedError,
-  UserDoesNotHavePushNotificationsError,
-  AuthorizationRequestExpiredError,
-  AuthorizationPending,
-  AuthorizationRequired,
-  AuthorizationPollingError,
+  AccessDeniedInterrupt,
+  UserDoesNotHavePushNotificationsInterrupt,
+  AuthorizationRequestExpiredInterrupt,
+  AuthorizationPendingInterrupt,
+  AuthorizationRequiredInterrupt,
+  AuthorizationPollingInterrupt,
 } from "./CIBAInterrupts";

--- a/packages/ai/test/ciba-authorizer-base.test.ts
+++ b/packages/ai/test/ciba-authorizer-base.test.ts
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { asyncLocalStorage, CIBAAuthorizerBase } from "../src/authorizers/ciba";
 import {
-  AccessDeniedError,
-  AuthorizationPending,
-  AuthorizationRequestExpiredError,
+  AccessDeniedInterrupt,
+  AuthorizationPendingInterrupt,
+  AuthorizationRequestExpiredInterrupt,
 } from "../src/interrupts";
 
 vi.mock("auth0");
@@ -74,7 +74,7 @@ describe("CIBAAuthorizerBase", () => {
    * and the backchannel.authorize should be called.
    *
    * As the request is still pending the protected function will throw an
-   * AuthorizationPending error.
+   * AuthorizationPendingInterrupt error.
    */
   describe("first call", () => {
     const authorizeResponse = {
@@ -114,8 +114,8 @@ describe("CIBAAuthorizerBase", () => {
       );
     });
 
-    it('should throw "AuthorizationPending" error', async () => {
-      expect(err).toBeInstanceOf(AuthorizationPending);
+    it('should throw "AuthorizationPendingInterrupt" error', async () => {
+      expect(err).toBeInstanceOf(AuthorizationPendingInterrupt);
     });
   });
 
@@ -124,7 +124,7 @@ describe("CIBAAuthorizerBase", () => {
    * and the backchannel.authorize should be called.
    *
    * As the request is still pending the protected function will throw an
-   * AuthorizationPending error.
+   * AuthorizationPendingInterrupt error.
    */
   describe("first call", () => {
     const authorizeResponse = {
@@ -164,8 +164,8 @@ describe("CIBAAuthorizerBase", () => {
       );
     });
 
-    it('should throw "AuthorizationPending" error', async () => {
-      expect(err).toBeInstanceOf(AuthorizationPending);
+    it('should throw "AuthorizationPendingInterrupt" error', async () => {
+      expect(err).toBeInstanceOf(AuthorizationPendingInterrupt);
     });
 
     it("should not execute the protected function", async () => {
@@ -179,7 +179,7 @@ describe("CIBAAuthorizerBase", () => {
    * should be called throwing an authorization_pending error.
    *
    * As the request is still pending the protected function will throw an
-   * AuthorizationPending error.
+   * AuthorizationPendingInterrupt error.
    */
   describe("pending request", () => {
     const storedAuthorizationResponse = {
@@ -219,8 +219,8 @@ describe("CIBAAuthorizerBase", () => {
       );
     });
 
-    it('should throw "AuthorizationPending" error', async () => {
-      expect(err).toBeInstanceOf(AuthorizationPending);
+    it('should throw "AuthorizationPendingInterrupt" error', async () => {
+      expect(err).toBeInstanceOf(AuthorizationPendingInterrupt);
     });
   });
 
@@ -327,14 +327,14 @@ describe("CIBAAuthorizerBase", () => {
       );
     });
 
-    it('should throw "AccessDeniedError" error', async () => {
-      expect(err).toBeInstanceOf(AccessDeniedError);
+    it('should throw "AccessDeniedInterrupt" error', async () => {
+      expect(err).toBeInstanceOf(AccessDeniedInterrupt);
     });
   });
 
   /**
    * If the request expires  the protected function
-   * should throw an AuthorizationRequestExpiredError.
+   * should throw an AuthorizationRequestExpiredInterrupt.
    */
   describe("expired request", () => {
     const storedAuthorizationResponse = {
@@ -375,8 +375,8 @@ describe("CIBAAuthorizerBase", () => {
       );
     });
 
-    it('should throw "AccessDeniedError" error', async () => {
-      expect(err).toBeInstanceOf(AuthorizationRequestExpiredError);
+    it('should throw "AccessDeniedInterrupt" error', async () => {
+      expect(err).toBeInstanceOf(AuthorizationRequestExpiredInterrupt);
     });
   });
 });

--- a/packages/ai/test/fga-authorizer-base.test.ts
+++ b/packages/ai/test/fga-authorizer-base.test.ts
@@ -7,7 +7,7 @@ import {
   OpenFgaClient,
 } from "@openfga/sdk";
 
-import { FGAAuthorizerBase, FGAAuthorizerParams } from "../src/authorizers/fga";
+import { FGAAuthorizerBase, FGAClientParams } from "../src/authorizers/fga";
 
 vi.mock("@openfga/sdk", () => {
   return {
@@ -84,7 +84,7 @@ describe("FGAAuthorizerBase", () => {
     });
 
     it("should initialize with provided parameters", async () => {
-      const params: FGAAuthorizerParams = {
+      const params: FGAClientParams = {
         apiUrl: "https://custom.api.url",
         storeId: "custom_store_id",
         credentials: {
@@ -133,7 +133,7 @@ describe("FGAAuthorizerBase", () => {
       process.env.FGA_CLIENT_ID = "env_client_id";
       process.env.FGA_CLIENT_SECRET = "env_client_secret";
 
-      const params: FGAAuthorizerParams = {
+      const params: FGAClientParams = {
         storeId: "partial_store_id",
       };
 
@@ -168,7 +168,7 @@ describe("FGAAuthorizerBase", () => {
     it("should handle missing environment variables gracefully", async () => {
       process.env.FGA_STORE_ID = "env_store_id";
 
-      const params: FGAAuthorizerParams = {};
+      const params: FGAClientParams = {};
 
       const buildQueryMock = vi.fn().mockResolvedValue({
         user: "user",
@@ -322,5 +322,4 @@ describe("FGAAuthorizerBase", () => {
       });
     });
   });
-
 });

--- a/packages/ai/test/interrupts.test.ts
+++ b/packages/ai/test/interrupts.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  Auth0Interrupt,
+  AuthorizationRequestExpiredInterrupt,
+  CIBAInterrupt,
+  FederatedConnectionInterrupt,
+} from "../src/interrupts";
+
+describe("interrupts", () => {
+  it("should properly assert is an auth0interrupt", () => {
+    const auth0Interrupt = { name: "AUTH0_AI_INTERRUPT" };
+    expect(Auth0Interrupt.isInterrupt(auth0Interrupt)).toBe(true);
+  });
+
+  it("should properly assert not an interrupt", () => {
+    const auth0Interrupt = { name: "FOO" };
+    expect(Auth0Interrupt.isInterrupt(auth0Interrupt)).toBe(false);
+  });
+
+  describe("FederatedConnectionInterrupt", () => {
+    let interrupt: FederatedConnectionInterrupt;
+    let serialized: any;
+    beforeEach(() => {
+      interrupt = new FederatedConnectionInterrupt(
+        "this is a message",
+        "google-oauth2",
+        ["email"],
+        ["email"]
+      );
+      serialized = interrupt.toJSON();
+    });
+
+    it("should contain the interrupt options", () => {
+      expect(serialized).toMatchInlineSnapshot(`
+        {
+          "code": "FEDERATED_CONNECTION_ERROR",
+          "connection": "google-oauth2",
+          "message": "this is a message",
+          "name": "AUTH0_AI_INTERRUPT",
+          "requiredScopes": [
+            "email",
+          ],
+          "scopes": [
+            "email",
+          ],
+        }
+      `);
+    });
+
+    it("should properly assert the serialized version", () => {
+      expect(FederatedConnectionInterrupt.isInterrupt(serialized)).toBe(true);
+    });
+
+    it("should properly assert the instance", () => {
+      expect(FederatedConnectionInterrupt.isInterrupt(interrupt)).toBe(true);
+    });
+
+    it("should properly assert is an auth0interrupt", () => {
+      expect(Auth0Interrupt.isInterrupt(interrupt)).toBe(true);
+    });
+  });
+
+  describe("CIBAInterrupt", () => {
+    let interrupt: CIBAInterrupt;
+    let serialized: any;
+
+    beforeEach(() => {
+      interrupt = new AuthorizationRequestExpiredInterrupt(
+        "The request has expired"
+      );
+      serialized = interrupt.toJSON();
+    });
+
+    it("should contain the interrupt options", () => {
+      expect(serialized).toMatchInlineSnapshot(`
+        {
+          "code": "CIBA_AUTHORIZATION_REQUEST_EXPIRED",
+          "message": "The request has expired",
+          "name": "AUTH0_AI_INTERRUPT",
+        }
+      `);
+    });
+
+    it("should properly assert the serialized version with the base class", () => {
+      expect(CIBAInterrupt.isInterrupt(serialized)).toBe(true);
+    });
+
+    it("should properly assert the instance with the base class", () => {
+      expect(CIBAInterrupt.isInterrupt(interrupt)).toBe(true);
+    });
+
+    it("should properly assert the serialized version", () => {
+      expect(AuthorizationRequestExpiredInterrupt.isInterrupt(serialized)).toBe(
+        true
+      );
+    });
+
+    it("should properly assert the instance", () => {
+      expect(AuthorizationRequestExpiredInterrupt.isInterrupt(interrupt)).toBe(
+        true
+      );
+    });
+
+    it("should not match other interrupts", () => {
+      expect(FederatedConnectionInterrupt.isInterrupt(interrupt)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This pull request includes several changes to the `Auth0Interrupt` class and its related interrupt classes, aiming to standardize the naming and handling of interrupts, as well as improving type safety and readability. The most important changes include modifying how interrupts are checked, renaming interrupt classes for consistency, and updating relevant imports and usage throughout the codebase.

Improvements to interrupt handling:

* [`packages/ai/src/interrupts/Auth0Interrupt.ts`](diffhunk://#diff-321bfe64e1e811f14b66e4a912fff5bedfe91a30247b1badd0944c1edf876fb6R1-L10): Introduced a type alias `Auth0InterruptData` for generalized interrupt types, standardized the `toJSON` method, and updated the `isInterrupt` method to assert the data part of the interrupt. [[1]](diffhunk://#diff-321bfe64e1e811f14b66e4a912fff5bedfe91a30247b1badd0944c1edf876fb6R1-L10) [[2]](diffhunk://#diff-321bfe64e1e811f14b66e4a912fff5bedfe91a30247b1badd0944c1edf876fb6L23-R59)

Renaming and standardizing interrupt classes:

* [`packages/ai/src/interrupts/CIBAInterrupts.ts`](diffhunk://#diff-c50ea2e6eab96e9cd1b9966335476ca8735376cc34949debd7ae5a41e4576f55L1-R58): Renamed various interrupt classes (e.g., `AuthorizationPending` to `AuthorizationPendingInterrupt`) and updated their static `code` properties for consistency.
* [`packages/ai/src/interrupts/FederatedConnectionInterrupt.ts`](diffhunk://#diff-3c99af446d46f882ad3639a2eff800446ec169aaf83ac072dc45e88063168515L26-R26): Updated the static `code` property to use `const`.
* [`packages/ai/src/interrupts/index.ts`](diffhunk://#diff-3483b650da3648e36502a38b38d1fc689dc9d9a9fdf57d6e93429148897e7bf4L8-R13): Updated exports to reflect the new interrupt class names.

Updating imports and usage:

* `demos/nextjs-ai/components/chat.tsx`, `demos/nextjs-ai/components/langgraph/chat.tsx`, `demos/vercel-ai-agent/src/worker/handlers/conditional_trade.ts`: Updated imports and usage of renamed interrupt classes and methods. [[1]](diffhunk://#diff-29f97d9cef27cc09b956fd2731fc30d03f5ae8139dd08281050a42d0504eaf7cL8-R8) [[2]](diffhunk://#diff-29f97d9cef27cc09b956fd2731fc30d03f5ae8139dd08281050a42d0504eaf7cL45-R42) [[3]](diffhunk://#diff-69f3a45a25b4de2562556cc93cae19f2d13d08c04355aeb56c6fb4bb24ac33a8L6-R6) [[4]](diffhunk://#diff-69f3a45a25b4de2562556cc93cae19f2d13d08c04355aeb56c6fb4bb24ac33a8L18-R18) [[5]](diffhunk://#diff-69f3a45a25b4de2562556cc93cae19f2d13d08c04355aeb56c6fb4bb24ac33a8L44-R44) [[6]](diffhunk://#diff-69f3a45a25b4de2562556cc93cae19f2d13d08c04355aeb56c6fb4bb24ac33a8L75-R75) [[7]](diffhunk://#diff-73bf4f3fb670686ce51b1c11fa6fda6a8b12434d429fa7af88d8e46f338a05acL13-R14) [[8]](diffhunk://#diff-73bf4f3fb670686ce51b1c11fa6fda6a8b12434d429fa7af88d8e46f338a05acL87-R87) [[9]](diffhunk://#diff-73bf4f3fb670686ce51b1c11fa6fda6a8b12434d429fa7af88d8e46f338a05acL97-R102)

Updating tests:

* `packages/ai-vercel/test/CIBAAuthorizer.test.ts`, `packages/ai/test/ciba-authorizer-base.test.ts`: Updated imports and assertions to use the new interrupt class names. [[1]](diffhunk://#diff-29d34b5a6190a185530a9a27779db6e24f98d287065398a066c820634721582bL8-R9) [[2]](diffhunk://#diff-29d34b5a6190a185530a9a27779db6e24f98d287065398a066c820634721582bL66-R66) [[3]](diffhunk://#diff-29d34b5a6190a185530a9a27779db6e24f98d287065398a066c820634721582bL100-R100) [[4]](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL6-R8) [[5]](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL77-R77) [[6]](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL117-R118) [[7]](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL127-R127) [[8]](diffhunk://#diff-da5b01b9aa3a13dece93f5ea7f49fbcc64591dc222c3b27fa9deba39c2f3a5cbL167-R168)Similar to Buffer.isBuffer or Stream.isStream, interrupts have now `Interrupt.isInterrupt` to check if an object is an interrupt.

Every derived class has the isInterrupt static method to check if an object is an interrupt of that particular type.

Eg:

```js
// true if interrupt is a FederatedConnectionInterrupt
FederatedConnectionInterrupt.isInterrupt(interrupt)
```

This is works both in javascript for matching the object returning true or false but also is a user-defined type guard in typescript which gives.