### PR TITLE
chore(dep): remove z as dependency

### DIFF
--- a/demos/vercel-ai-agent/package.json
+++ b/demos/vercel-ai-agent/package.json
@@ -27,7 +27,6 @@
     "ioredis": "^5.5.0",
     "ms": "^2.1.3",
     "nodemailer": "^6.10.0",
-    "z": "^1.0.1",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,6 @@
         "ioredis": "^5.5.0",
         "ms": "^2.1.3",
         "nodemailer": "^6.10.0",
-        "z": "^1.0.1",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -10693,6 +10692,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -11890,26 +11890,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arguments": "^1.1.1",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.5.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -11967,6 +11947,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -11996,6 +11977,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -13921,15 +13903,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/flat": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.2.tgz",
-      "integrity": "sha512-b/cdFAr468cVs8XoG62dbGf9YegchdgEPX6sP7rppE0a4+RZF19kseTiDKGA1rIr3hOvOD0QIlSmaFlOlT0gfA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "is-buffer": "~1.1.2"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -14205,6 +14178,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14972,6 +14946,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -15289,15 +15264,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/install": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.10.4.tgz",
-      "integrity": "sha512-+IRyOastuPmLVx9zlVXJoKErSqz1Ma5at9A7S8yfsj3W+Kg95faPoh3bPDtMrZ/grz4PRmXzrswmlzfLlYyLOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -15344,22 +15310,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -15454,12 +15404,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
-    },
     "node_modules/is-bun-module": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-1.3.0.tgz",
@@ -15520,6 +15464,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -15696,6 +15641,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -16002,11 +15948,6 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
       "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/js-function-reflector": {
-      "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/leonardiwagner/js-function-reflector.git#f3a1295909cf870bbb7bb136ca53796fc3e87c17",
-      "license": "MIT"
     },
     "node_modules/js-tiktoken": {
       "version": "1.0.19",
@@ -18068,26 +18009,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -19750,6 +19676,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -20242,6 +20169,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -20259,6 +20187,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -22905,21 +22834,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/z": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/z/-/z-1.0.9.tgz",
-      "integrity": "sha512-Vocq47YR4WoT+4wu80VsJwKi0Y92R20Vqq7AxghN9KFIa4J4CUae1uKnwtv4w33QvjnKjb/7rWHRC93TFQc0jA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal": "^1.0.1",
-        "flat": "^2.0.1",
-        "install": "^0.10.0",
-        "js-function-reflector": "git+https://github.com/leonardiwagner/js-function-reflector.git"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/zod": {
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
@@ -22994,8 +22908,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@auth0/ai": "*",
-        "genkit": "^0.9.12",
-        "z": "1.0.1"
+        "genkit": "^0.9.12"
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.7",
@@ -23247,25 +23160,13 @@
         "node": ">=8"
       }
     },
-    "packages/ai-genkit/node_modules/z": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/z/-/z-1.0.1.tgz",
-      "integrity": "sha512-ihtWu3wmyR8ZZDn2eAlhVSvucGaMC50QT7+BBW0DHIlHfAJcVbC8ItviAJdq51Hb0eplavFPf7iNJW59gBI4Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal": "^1.0.1",
-        "install": "^0.10.0",
-        "js-function-reflector": "git+https://github.com/leonardiwagner/js-function-reflector.git"
-      }
-    },
     "packages/ai-langchain": {
       "name": "@auth0/ai-langchain",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@auth0/ai": "*",
-        "langchain": "^0.3.11",
-        "z": "1.0.1"
+        "langchain": "^0.3.11"
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.7",
@@ -23521,17 +23422,6 @@
         "node": ">=8"
       }
     },
-    "packages/ai-langchain/node_modules/z": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/z/-/z-1.0.1.tgz",
-      "integrity": "sha512-ihtWu3wmyR8ZZDn2eAlhVSvucGaMC50QT7+BBW0DHIlHfAJcVbC8ItviAJdq51Hb0eplavFPf7iNJW59gBI4Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal": "^1.0.1",
-        "install": "^0.10.0",
-        "js-function-reflector": "git+https://github.com/leonardiwagner/js-function-reflector.git"
-      }
-    },
     "packages/ai-llamaindex": {
       "name": "@auth0/ai-llamaindex",
       "version": "0.0.0",
@@ -23541,8 +23431,7 @@
         "html-to-text": "^9.0.5",
         "llamaindex": "^0.9",
         "lodash": "^4.17.21",
-        "magic-bytes.js": "^1.10.0",
-        "z": "1.0.1"
+        "magic-bytes.js": "^1.10.0"
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.7",
@@ -23922,25 +23811,13 @@
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "license": "MIT"
     },
-    "packages/ai-llamaindex/node_modules/z": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/z/-/z-1.0.1.tgz",
-      "integrity": "sha512-ihtWu3wmyR8ZZDn2eAlhVSvucGaMC50QT7+BBW0DHIlHfAJcVbC8ItviAJdq51Hb0eplavFPf7iNJW59gBI4Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal": "^1.0.1",
-        "install": "^0.10.0",
-        "js-function-reflector": "git+https://github.com/leonardiwagner/js-function-reflector.git"
-      }
-    },
     "packages/ai-vercel": {
       "name": "@auth0/ai-vercel",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@auth0/ai": "*",
-        "auth0": "^4.18.0",
-        "z": "1.0.1"
+        "auth0": "^4.18.0"
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.7",
@@ -24192,17 +24069,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/ai-vercel/node_modules/z": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/z/-/z-1.0.1.tgz",
-      "integrity": "sha512-ihtWu3wmyR8ZZDn2eAlhVSvucGaMC50QT7+BBW0DHIlHfAJcVbC8ItviAJdq51Hb0eplavFPf7iNJW59gBI4Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal": "^1.0.1",
-        "install": "^0.10.0",
-        "js-function-reflector": "git+https://github.com/leonardiwagner/js-function-reflector.git"
       }
     },
     "packages/ai/node_modules/@types/node": {

--- a/packages/ai-genkit/package.json
+++ b/packages/ai-genkit/package.json
@@ -33,8 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@auth0/ai": "*",
-    "genkit": "^0.9.12",
-    "z": "1.0.1"
+    "genkit": "^0.9.12"
   },
   "peerDependencies": {
     "@openfga/sdk": "^0.8.0"

--- a/packages/ai-langchain/package.json
+++ b/packages/ai-langchain/package.json
@@ -33,8 +33,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@auth0/ai": "*",
-    "langchain": "^0.3.11",
-    "z": "1.0.1"
+    "langchain": "^0.3.11"
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.19",

--- a/packages/ai-llamaindex/package.json
+++ b/packages/ai-llamaindex/package.json
@@ -36,8 +36,7 @@
     "html-to-text": "^9.0.5",
     "llamaindex": "^0.9",
     "lodash": "^4.17.21",
-    "magic-bytes.js": "^1.10.0",
-    "z": "1.0.1"
+    "magic-bytes.js": "^1.10.0"
   },
   "peerDependencies": {
     "@openfga/sdk": "^0.8.0"

--- a/packages/ai-vercel/package.json
+++ b/packages/ai-vercel/package.json
@@ -50,8 +50,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@auth0/ai": "*",
-    "auth0": "^4.18.0",
-    "z": "1.0.1"
+    "auth0": "^4.18.0"
   },
   "peerDependencies": {
     "ai": "^4.1.54",


### PR DESCRIPTION
This pull request involves the removal of the `z` package from various `package.json` files across multiple projects. The most important changes include the deletion of the `z` package from the dependencies in several files.

Package cleanup:

* [`demos/vercel-ai-agent/package.json`](diffhunk://#diff-962c68ed2310e64e35f08c59dfa5523724c8b6dcf657f14eafb89541be373d43L30): Removed the `z` package from dependencies.
* [`packages/ai-genkit/package.json`](diffhunk://#diff-c6a418b63601c8cd1ebb9280658c36c7afce12b9a7444a40705de54d18c1c983L36-R36): Removed the `z` package from dependencies.
* [`packages/ai-langchain/package.json`](diffhunk://#diff-2d0aede74b38e61ff841e237af368e676506ebaf46f123bbe7ed389a86df0bd6L36-R36): Removed the `z` package from dependencies.
* [`packages/ai-llamaindex/package.json`](diffhunk://#diff-a88e0376c9b2001bd301cbaf4fc59baa622a0ec2dce294f0cd4131946af5b5c2L39-R39): Removed the `z` package from dependencies.
* [`packages/ai-vercel/package.json`](diffhunk://#diff-58aa606e03887c81c436e799d7cb8d4a0c422a590d7222c9905188dde4cd5afcL53-R53): Removed the `z` package from dependencies.