### PR TITLE
chore(docs): update all exampels and demos pkg names and privacy

### DIFF
--- a/demos/nextjs-ai/package.json
+++ b/demos/nextjs-ai/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nextjs-ai",
-  "version": "0.1.0",
+  "name": "@auth0/auth0-ai-js-demos-nextjs-ai",
   "private": true,
+  "version": "0.1.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "start": "next start"

--- a/demos/vercel-ai-agent/package.json
+++ b/demos/vercel-ai-agent/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vercel-ai-agent",
-  "version": "1.0.0",
+  "name": "@auth0/auth0-ai-js-demos-vercel-ai-agent",
   "private": true,
+  "version": "1.0.0",
   "scripts": {
     "queue-job": "tsx --env-file=.env.local src/queue/index.ts",
     "worker": "tsx --env-file=.env.local src/worker/index.ts",

--- a/examples/async-user-confirmation/ai-sdk/package.json
+++ b/examples/async-user-confirmation/ai-sdk/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-step-up-ai-sdk",
+  "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-ai-sdk",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/async-user-confirmation/genkit/package.json
+++ b/examples/async-user-confirmation/genkit/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-step-up-genkit",
+  "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-genkit",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/async-user-confirmation/langchain/package.json
+++ b/examples/async-user-confirmation/langchain/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-step-up-langchain",
+  "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-langchain",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/async-user-confirmation/llamaindex/package.json
+++ b/examples/async-user-confirmation/llamaindex/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-step-up-llamaindex",
+  "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-llamaindex",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/async-user-confirmation/sample-api/package.json
+++ b/examples/async-user-confirmation/sample-api/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-api-sample",
+  "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-sample-api",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "app.js",

--- a/examples/authorization-for-rag/genkit/package.json
+++ b/examples/authorization-for-rag/genkit/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "genkit-retrievers-with-fga",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-genkit",
+  "private": true,
   "version": "0.0.0",
   "description": "Demonstrates the usage of the Okta FGA with a genkit to query documents with permission checks.",
   "x-type": "module",

--- a/examples/authorization-for-rag/langchain/package.json
+++ b/examples/authorization-for-rag/langchain/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "langchain-retrievers-with-fga",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-langchain",
+  "private": true,
   "version": "0.0.0",
   "description": "Demonstrates the usage of the Okta FGA with LangChain to query documents with permission checks.",
   "x-type": "module",

--- a/examples/authorization-for-rag/langgraph-agentic/package.json
+++ b/examples/authorization-for-rag/langgraph-agentic/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "auth0-langgraph-agentic-rag-js",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-langgraph-agentic",
+  "private": true,
   "version": "0.0.0",
   "description": "Demonstrates the usage of the Okta FGA with LangChain to query documents with permission checks.",
   "x-type": "module",

--- a/examples/authorization-for-rag/langgraph-stategraph/package.json
+++ b/examples/authorization-for-rag/langgraph-stategraph/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "auth0-langgraph-state-rag-js",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-langgraph-stategraph",
+  "private": true,
   "version": "0.0.0",
   "description": "Demonstrates the usage of the Okta FGA with LangChain to query documents with permission checks.",
   "x-type": "module",

--- a/examples/authorization-for-rag/llamaindex/package.json
+++ b/examples/authorization-for-rag/llamaindex/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "llamaindex-retrievers-with-fga",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-llamaindex",
+  "private": true,
   "version": "0.0.0",
   "description": "Demonstrates the usage of the Okta FGA with a llamaindex to query documents with permission checks.",
   "x-type": "module",

--- a/examples/authorization-for-tools/ai-sdk/package.json
+++ b/examples/authorization-for-tools/ai-sdk/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-authorization-for-tools-ai-sdk",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-tools-ai-sdk",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/authorization-for-tools/genkit/package.json
+++ b/examples/authorization-for-tools/genkit/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-authorization-for-tools-genkit",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-tools-genkit",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/authorization-for-tools/langchain/package.json
+++ b/examples/authorization-for-tools/langchain/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-authorization-for-tools-langchain",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-tools-langchain",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/authorization-for-tools/llamaindex/package.json
+++ b/examples/authorization-for-tools/llamaindex/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@auth0-ai-js/examples-authorization-for-tools-llamaindex",
+  "name": "@auth0/auth0-ai-js-examples-authorization-for-tools-llamaindex",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/calling-apis/langgraph/package.json
+++ b/examples/calling-apis/langgraph/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@auth0-ai-js/examples-langchain-federated-connections",
+  "name": "@auth0/auth0-ai-js-examples-calling-apis-langgraph",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "start": "npx @langchain/langgraph-cli up",
     "dev": "npx @langchain/langgraph-cli dev --port 54367",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       }
     },
     "demos/nextjs-ai": {
+      "name": "@auth0/auth0-ai-js-demos-nextjs-ai",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -105,6 +106,7 @@
       }
     },
     "demos/vercel-ai-agent": {
+      "name": "@auth0/auth0-ai-js-demos-vercel-ai-agent",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -290,7 +292,7 @@
       }
     },
     "examples/async-user-confirmation/ai-sdk": {
-      "name": "@auth0-ai-js/examples-step-up-ai-sdk",
+      "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-ai-sdk",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -302,7 +304,7 @@
       }
     },
     "examples/async-user-confirmation/genkit": {
-      "name": "@auth0-ai-js/examples-step-up-genkit",
+      "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-genkit",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -314,7 +316,7 @@
       }
     },
     "examples/async-user-confirmation/langchain": {
-      "name": "@auth0-ai-js/examples-step-up-langchain",
+      "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-langchain",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -344,7 +346,7 @@
       "link": true
     },
     "examples/async-user-confirmation/llamaindex": {
-      "name": "@auth0-ai-js/examples-step-up-llamaindex",
+      "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-llamaindex",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -356,7 +358,7 @@
       }
     },
     "examples/async-user-confirmation/sample-api": {
-      "name": "@auth0-ai-js/examples-api-sample",
+      "name": "@auth0/auth0-ai-js-examples-async-user-confirmation-sample-api",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -373,7 +375,7 @@
       }
     },
     "examples/authorization-for-rag/genkit": {
-      "name": "genkit-retrievers-with-fga",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-genkit",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -386,7 +388,7 @@
       }
     },
     "examples/authorization-for-rag/langchain": {
-      "name": "langchain-retrievers-with-fga",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-langchain",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -411,7 +413,7 @@
       }
     },
     "examples/authorization-for-rag/langgraph-agentic": {
-      "name": "auth0-langgraph-agentic-rag-js",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-langgraph-agentic",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -439,7 +441,7 @@
       }
     },
     "examples/authorization-for-rag/langgraph-stategraph": {
-      "name": "auth0-langgraph-state-rag-js",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-langgraph-stategraph",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -467,7 +469,7 @@
       }
     },
     "examples/authorization-for-rag/llamaindex": {
-      "name": "llamaindex-retrievers-with-fga",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-rag-llamaindex",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -482,7 +484,7 @@
       "link": true
     },
     "examples/authorization-for-tools/ai-sdk": {
-      "name": "@auth0-ai-js/examples-authorization-for-tools-ai-sdk",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-tools-ai-sdk",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -496,7 +498,7 @@
       }
     },
     "examples/authorization-for-tools/genkit": {
-      "name": "@auth0-ai-js/examples-authorization-for-tools-genkit",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-tools-genkit",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -510,7 +512,7 @@
       }
     },
     "examples/authorization-for-tools/langchain": {
-      "name": "@auth0-ai-js/examples-authorization-for-tools-langchain",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-tools-langchain",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -527,7 +529,7 @@
       }
     },
     "examples/authorization-for-tools/llamaindex": {
-      "name": "@auth0-ai-js/examples-authorization-for-tools-llamaindex",
+      "name": "@auth0/auth0-ai-js-examples-authorization-for-tools-llamaindex",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -569,7 +571,7 @@
       "extraneous": true
     },
     "examples/calling-apis/langgraph": {
-      "name": "@auth0-ai-js/examples-langchain-federated-connections",
+      "name": "@auth0/auth0-ai-js-examples-calling-apis-langgraph",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -913,46 +915,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/@auth0-ai-js/examples-api-sample": {
-      "resolved": "examples/async-user-confirmation/sample-api",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-authorization-for-tools-ai-sdk": {
-      "resolved": "examples/authorization-for-tools/ai-sdk",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-authorization-for-tools-genkit": {
-      "resolved": "examples/authorization-for-tools/genkit",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-authorization-for-tools-langchain": {
-      "resolved": "examples/authorization-for-tools/langchain",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-authorization-for-tools-llamaindex": {
-      "resolved": "examples/authorization-for-tools/llamaindex",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-langchain-federated-connections": {
-      "resolved": "examples/calling-apis/langgraph",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-step-up-ai-sdk": {
-      "resolved": "examples/async-user-confirmation/ai-sdk",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-step-up-genkit": {
-      "resolved": "examples/async-user-confirmation/genkit",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-step-up-langchain": {
-      "resolved": "examples/async-user-confirmation/langchain",
-      "link": true
-    },
-    "node_modules/@auth0-ai-js/examples-step-up-llamaindex": {
-      "resolved": "examples/async-user-confirmation/llamaindex",
-      "link": true
-    },
     "node_modules/@auth0/ai": {
       "resolved": "packages/ai",
       "link": true
@@ -975,6 +937,74 @@
     },
     "node_modules/@auth0/ai-vercel": {
       "resolved": "packages/ai-vercel",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-demos-nextjs-ai": {
+      "resolved": "demos/nextjs-ai",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-demos-vercel-ai-agent": {
+      "resolved": "demos/vercel-ai-agent",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-async-user-confirmation-ai-sdk": {
+      "resolved": "examples/async-user-confirmation/ai-sdk",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-async-user-confirmation-genkit": {
+      "resolved": "examples/async-user-confirmation/genkit",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-async-user-confirmation-langchain": {
+      "resolved": "examples/async-user-confirmation/langchain",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-async-user-confirmation-llamaindex": {
+      "resolved": "examples/async-user-confirmation/llamaindex",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-async-user-confirmation-sample-api": {
+      "resolved": "examples/async-user-confirmation/sample-api",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-rag-genkit": {
+      "resolved": "examples/authorization-for-rag/genkit",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-rag-langchain": {
+      "resolved": "examples/authorization-for-rag/langchain",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-rag-langgraph-agentic": {
+      "resolved": "examples/authorization-for-rag/langgraph-agentic",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-rag-langgraph-stategraph": {
+      "resolved": "examples/authorization-for-rag/langgraph-stategraph",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-rag-llamaindex": {
+      "resolved": "examples/authorization-for-rag/llamaindex",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-tools-ai-sdk": {
+      "resolved": "examples/authorization-for-tools/ai-sdk",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-tools-genkit": {
+      "resolved": "examples/authorization-for-tools/genkit",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-tools-langchain": {
+      "resolved": "examples/authorization-for-tools/langchain",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-authorization-for-tools-llamaindex": {
+      "resolved": "examples/authorization-for-tools/llamaindex",
+      "link": true
+    },
+    "node_modules/@auth0/auth0-ai-js-examples-calling-apis-langgraph": {
+      "resolved": "examples/calling-apis/langgraph",
       "link": true
     },
     "node_modules/@auth0/nextjs-auth0": {
@@ -10263,14 +10293,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/auth0-langgraph-agentic-rag-js": {
-      "resolved": "examples/authorization-for-rag/langgraph-agentic",
-      "link": true
-    },
-    "node_modules/auth0-langgraph-state-rag-js": {
-      "resolved": "examples/authorization-for-rag/langgraph-stategraph",
-      "link": true
-    },
     "node_modules/auth0/node_modules/jose": {
       "version": "4.15.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
@@ -14462,10 +14484,6 @@
         "uuid": "^10.0.0"
       }
     },
-    "node_modules/genkit-retrievers-with-fga": {
-      "resolved": "examples/authorization-for-rag/genkit",
-      "link": true
-    },
     "node_modules/genkitx-openai": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/genkitx-openai/-/genkitx-openai-0.12.0.tgz",
@@ -16381,10 +16399,6 @@
         }
       }
     },
-    "node_modules/langchain-retrievers-with-fga": {
-      "resolved": "examples/authorization-for-rag/langchain",
-      "link": true
-    },
     "node_modules/langgraph-nextjs-api-passthrough": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/langgraph-nextjs-api-passthrough/-/langgraph-nextjs-api-passthrough-0.0.3.tgz",
@@ -16820,10 +16834,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/llamaindex-retrievers-with-fga": {
-      "resolved": "examples/authorization-for-rag/llamaindex",
-      "link": true
     },
     "node_modules/llamaindex/node_modules/@types/node": {
       "version": "22.13.10",
@@ -17739,10 +17749,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/nextjs-ai": {
-      "resolved": "demos/nextjs-ai",
-      "link": true
     },
     "node_modules/nice-grpc": {
       "version": "2.1.11",
@@ -22138,10 +22144,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/vercel-ai-agent": {
-      "resolved": "demos/vercel-ai-agent",
-      "link": true
     },
     "node_modules/vite": {
       "version": "6.2.2",


### PR DESCRIPTION
This pull request includes multiple changes to the `package.json` files across various demo and example projects. The main goal of these changes is to update the package names and ensure they are marked as private.

Changes to package names and privacy settings:

* [`demos/nextjs-ai/package.json`](diffhunk://#diff-b4894c0d871d44213386cc0cdcacc5a5b1efcc6738a3d63e5002ab48409076d3L2-R4): Updated package name to `@auth0/auth0-ai-js-demos-nextjs-ai` and added `private: true`.
* [`demos/vercel-ai-agent/package.json`](diffhunk://#diff-962c68ed2310e64e35f08c59dfa5523724c8b6dcf657f14eafb89541be373d43L2-R4): Updated package name to `@auth0/auth0-ai-js-demos-vercel-ai-agent` and added `private: true`.

Updates to async-user-confirmation examples:

* [`examples/async-user-confirmation/ai-sdk/package.json`](diffhunk://#diff-3cc0c46a48265db79ac4271f767932abbfb324d19c97722f43ed365cc9ec6a69L2-R3): Updated package name to `@auth0/auth0-ai-js-examples-async-user-confirmation-ai-sdk` and added `private: true`.
* [`examples/async-user-confirmation/genkit/package.json`](diffhunk://#diff-b9ce25136d54dfa376764c4f53290824a21601d47725b7c1a12cf2f1ba98f236L2-R3): Updated package name to `@auth0/auth0-ai-js-examples-async-user-confirmation-genkit` and added `private: true`.
* [`examples/async-user-confirmation/langchain/package.json`](diffhunk://#diff-9d009bc16764ee9199c7434421cd2994da21acd10be7f1364615445d1443dabaL2-R3): Updated package name to `@auth0/auth0-ai-js-examples-async-user-confirmation-langchain` and added `private: true`.

Updates to authorization-for-rag examples:

* [`examples/authorization-for-rag/genkit/package.json`](diffhunk://#diff-6d16ee39dab8084aadd7ea0385dc9dcef1694a1ef748adb011a9f02680d5f233L2-R3): Updated package name to `@auth0/auth0-ai-js-examples-authorization-for-rag-genkit` and added `private: true`.
* [`examples/authorization-for-rag/langchain/package.json`](diffhunk://#diff-223efc705b29b6cdc6d6a1829b4905111ea0e30c8cf22c644be9dfa7dc30c9b4L2-R3): Updated package name to `@auth0/auth0-ai-js-examples-authorization-for-rag-langchain` and added `private: true`.
* [`examples/authorization-for-rag/langgraph-agentic/package.json`](diffhunk://#diff-ab0deee5936ac43f2795c83bf4e5fcb71eee7bdf55f434f03d72421f84cc68caL2-R3): Updated package name to `@auth0/auth0-ai-js-examples-authorization-for-rag-langgraph-agentic` and added `private: true`.

Updates to authorization-for-tools examples:

* [`examples/authorization-for-tools/ai-sdk/package.json`](diffhunk://#diff-2605f12feb31eb05cd8f332d4deac1e87cce5440510a0565b597a9c9509c09deL2-R3): Updated package name to `@auth0/auth0-ai-js-examples-authorization-for-tools-ai-sdk` and added `private: true`.
* [`examples/authorization-for-tools/genkit/package.json`](diffhunk://#diff-8ac4e84d05ab4c2797be8abfbb61824783e53576b817873242141ada7f38882aL2-R3): Updated package name to `@auth0/auth0-ai-js-examples-authorization-for-tools-genkit` and added `private: true`.
* [`examples/authorization-for-tools/langchain/package.json`](diffhunk://#diff-ee086733e80bf024f813a5951dad17a8df65b1953b24dcc66a13354ab71f1fa3L2-R3): Updated package name to `@auth0/auth0-ai-js-examples-authorization-for-tools-langchain` and added `private: true`.

Updates to calling-apis example:

* [`examples/calling-apis/langgraph/package.json`](diffhunk://#diff-bb2b7824f02a332e24edbbdc6035bff0188372618bde1e0e6964a9f666cf98a2L2-L6): Updated package name to `@auth0/auth0-ai-js-examples-calling-apis-langgraph` and added `private: true`.