### PR TITLE
chore: fix generic types for genkit

### DIFF
--- a/packages/ai-genkit/src/FGA/FGAAuthorizer.ts
+++ b/packages/ai-genkit/src/FGA/FGAAuthorizer.ts
@@ -4,7 +4,7 @@ import { FGAAuthorizerBase } from "@auth0/ai/FGA";
 
 export type GenKitToolHandler<
   I extends z.ZodTypeAny,
-  O extends z.ZodTypeAny
+  O extends z.ZodTypeAny,
 > = (input: z.infer<I>) => Promise<z.infer<O>>;
 
 /**
@@ -22,10 +22,8 @@ export class FGAAuthorizer extends FGAAuthorizerBase<[any, any]> {
    * @returns A tool authorizer.
    */
   authorizer() {
-    return <I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
-      t: GenKitToolHandler<I, O>
-    ): GenKitToolHandler<I, O> => {
-      return this.protect(t) as GenKitToolHandler<I, O>;
+    return <T extends (...args: [any, any]) => any>(fn: T): T => {
+      return this.protect(fn) as T;
     };
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `FGAAuthorizer` and `FGA_AI` classes in the `ai-genkit` package to improve the handling and protection of tool functions with Fine Grained Authorization (FGA). The most important changes include modifying the `authorizer` method, updating type definitions, and adding detailed documentation comments.

Improvements to `FGAAuthorizer`:

* [`packages/ai-genkit/src/FGA/FGAAuthorizer.ts`](diffhunk://#diff-6919fa3301b57265b62f1a39d60d389b474b126c7b1f4c16bccda0b67c22b46fL25-R26): Modified the `authorizer` method to simplify the function signature and improve type safety by changing the generic parameters to a more flexible function type.

Updates to type definitions:

* [`packages/ai-genkit/src/FGA_AI.ts`](diffhunk://#diff-cbe71f3d03323933978fc762065cfb36ce971d7b4eadcd179f49931ec8ac343bL1-R9): Removed the import of `zod` and the `GenKitToolHandler` type, and introduced new type definitions `ToolFunc` and `ToolWrapper` to better align with the updated `authorizer` method.

Detailed documentation comments:

* [`packages/ai-genkit/src/FGA_AI.ts`](diffhunk://#diff-cbe71f3d03323933978fc762065cfb36ce971d7b4eadcd179f49931ec8ac343bR39-R67): Added comprehensive JSDoc comments to the `withFGA` method to describe its purpose, parameters, and return values, enhancing the code's readability and maintainability.