### PR TITLE
chore: fix semantic-release config

### DIFF
--- a/packages/ai-components/.releaserc.json
+++ b/packages/ai-components/.releaserc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tools/semantic-release/.releaserc.json"
+  "extends": [
+    "../../tools/semantic-release/.releaserc.json",
+    "semantic-release-monorepo"
+  ]
 }

--- a/packages/ai-genkit/.releaserc.json
+++ b/packages/ai-genkit/.releaserc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tools/semantic-release/.releaserc.json"
+  "extends": [
+    "../../tools/semantic-release/.releaserc.json",
+    "semantic-release-monorepo"
+  ]
 }

--- a/packages/ai-langchain/.releaserc.json
+++ b/packages/ai-langchain/.releaserc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tools/semantic-release/.releaserc.json"
+  "extends": [
+    "../../tools/semantic-release/.releaserc.json",
+    "semantic-release-monorepo"
+  ]
 }

--- a/packages/ai-llamaindex/.releaserc.json
+++ b/packages/ai-llamaindex/.releaserc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tools/semantic-release/.releaserc.json"
+  "extends": [
+    "../../tools/semantic-release/.releaserc.json",
+    "semantic-release-monorepo"
+  ]
 }

--- a/packages/ai-vercel/.releaserc.json
+++ b/packages/ai-vercel/.releaserc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tools/semantic-release/.releaserc.json"
+  "extends": [
+    "../../tools/semantic-release/.releaserc.json",
+    "semantic-release-monorepo"
+  ]
 }

--- a/packages/ai/.releaserc.json
+++ b/packages/ai/.releaserc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tools/semantic-release/.releaserc.json"
+  "extends": [
+    "../../tools/semantic-release/.releaserc.json",
+    "semantic-release-monorepo"
+  ]
 }

--- a/tools/semantic-release/.releaserc.json
+++ b/tools/semantic-release/.releaserc.json
@@ -1,19 +1,5 @@
 {
-  "extends": "semantic-release-monorepo",
   "branches": [
     "main"
-  ],
-  "plugins": [
-    [
-      "semantic-release-unsquash",
-      {
-        "@semantic-release/commit-analyzer": {
-          "preset": "conventionalcommits"
-        },
-        "@semantic-release/release-notes-generator": {
-          "preset": "conventionalcommits"
-        }
-      }
-    ]
   ]
 }


### PR DESCRIPTION
This pull request includes changes to the release configuration files for multiple packages. The primary change is the addition of the `semantic-release-monorepo` extension to the `.releaserc.json` files of various packages.

Changes to release configuration:

* [`packages/ai-components/.releaserc.json`](diffhunk://#diff-397596fdb288d89c5288937b87cf0f650724fc7df2c0a81cfd9463b61f513350L2-R5): Added `semantic-release-monorepo` extension.
* [`packages/ai-genkit/.releaserc.json`](diffhunk://#diff-397596fdb288d89c5288937b87cf0f650724fc7df2c0a81cfd9463b61f513350L2-R5): Added `semantic-release-monorepo` extension.
* [`packages/ai-langchain/.releaserc.json`](diffhunk://#diff-397596fdb288d89c5288937b87cf0f650724fc7df2c0a81cfd9463b61f513350L2-R5): Added `semantic-release-monorepo` extension.
* [`packages/ai-llamaindex/.releaserc.json`](diffhunk://#diff-397596fdb288d89c5288937b87cf0f650724fc7df2c0a81cfd9463b61f513350L2-R5): Added `semantic-release-monorepo` extension.
* [`packages/ai-vercel/.releaserc.json`](diffhunk://#diff-397596fdb288d89c5288937b87cf0f650724fc7df2c0a81cfd9463b61f513350L2-R5): Added `semantic-release-monorepo` extension.
* [`packages/ai/.releaserc.json`](diffhunk://#diff-397596fdb288d89c5288937b87cf0f650724fc7df2c0a81cfd9463b61f513350L2-R5): Added `semantic-release-monorepo` extension.

Additionally, the `semantic-release-monorepo` extension was removed from the `tools/semantic-release/.releaserc.json` file.