### PR TITLE
chore: fix publishConfig in package.json

### DIFF
--- a/packages/ai-components/package.json
+++ b/packages/ai-components/package.json
@@ -25,5 +25,8 @@
     "react-device-detect": "^2.2.3",
     "tailwind-merge": "^3.0.2",
     "typescript": "^5.7.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ai-genkit/package.json
+++ b/packages/ai-genkit/package.json
@@ -46,5 +46,8 @@
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
     "vitest": "^3.0.8"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ai-langchain/package.json
+++ b/packages/ai-langchain/package.json
@@ -55,5 +55,8 @@
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
     "vitest": "^3.0.8"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ai-llamaindex/package.json
+++ b/packages/ai-llamaindex/package.json
@@ -49,5 +49,8 @@
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
     "vitest": "^3.0.8"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ai-vercel/package.json
+++ b/packages/ai-vercel/package.json
@@ -65,5 +65,8 @@
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
     "vitest": "^3.0.8"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -69,5 +69,8 @@
     "jose": "^5.9.6",
     "open": "^10.1.0",
     "openid-client": "^6.1.7"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This pull request includes changes to multiple `package.json` files across various packages to add a `publishConfig` section. This change ensures that the packages are published with public access.

Changes to `package.json` files:

* [`packages/ai-components/package.json`](diffhunk://#diff-2f50ec3821f5cb76a6ae462829b37d48d92bea37bce79c2d36e7bd0bfcc93472R28-R30): Added `publishConfig` section to set access to public.
* [`packages/ai-genkit/package.json`](diffhunk://#diff-c6a418b63601c8cd1ebb9280658c36c7afce12b9a7444a40705de54d18c1c983R49-R51): Added `publishConfig` section to set access to public.
* [`packages/ai-langchain/package.json`](diffhunk://#diff-2d0aede74b38e61ff841e237af368e676506ebaf46f123bbe7ed389a86df0bd6R58-R60): Added `publishConfig` section to set access to public.
* [`packages/ai-llamaindex/package.json`](diffhunk://#diff-a88e0376c9b2001bd301cbaf4fc59baa622a0ec2dce294f0cd4131946af5b5c2R52-R54): Added `publishConfig` section to set access to public.
* [`packages/ai-vercel/package.json`](diffhunk://#diff-58aa606e03887c81c436e799d7cb8d4a0c422a590d7222c9905188dde4cd5afcR68-R70): Added `publishConfig` section to set access to public.
* [`packages/ai/package.json`](diffhunk://#diff-3758ea4fd63e4789bf712baab7b4b0227fce843a17e2ed535091b9c3b83ff2dfR72-R74): Added `publishConfig` section to set access to public.