### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - Continuous Integration
+    types:
+      - completed
+    branches: [main]
 
 permissions:
   contents: read # for checkout


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to improve the release process. The most important change is switching the trigger for the release workflow from a push event to a workflow run completion event.

Changes to GitHub Actions workflow configuration:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL4-R9): Changed the trigger for the release workflow from a push to the `main` branch to the completion of the Continuous Integration workflow on the `main` branch.