### PR TITLE
fix: fga example in langchain docs

### DIFF
--- a/packages/ai-langchain/README.md
+++ b/packages/ai-langchain/README.md
@@ -96,18 +96,20 @@ const useFGA = auth0AI.withFGA({
 });
 
 // 3. Tool definition
-export const buyTool = tool(
-  useFGA(async ({ ticker, qty }) => {
-    return `Purchased ${qty} shares of ${ticker}`;
-  }),
-  {
-    name: "buy",
-    description: "Use this function to buy stock",
-    schema: z.object({
-      ticker: z.string(),
-      qty: z.number(),
-    }),
-  }
+export const buyTool = useFGA(
+  tool(
+    async ({ ticker, qty }) => {
+      return `Purchased ${qty} shares of ${ticker}`;
+    },
+    {
+      name: "buy",
+      description: "Use this function to buy stock",
+      schema: z.object({
+        ticker: z.string(),
+        qty: z.number(),
+      }),
+    }
+  )
 );
 ```
 


### PR DESCRIPTION
This pull request includes changes to the `packages/ai-langchain/README.md` file to improve the tool definition and usage pattern for the `buyTool` function. The most important changes include modifying the `buyTool` definition to use `useFGA` and adjusting the function's structure for better clarity and functionality.

Improvements to tool definition and usage pattern:

* [`packages/ai-langchain/README.md`](diffhunk://#diff-8fb1cf4cde044d4166b3bda4d69c651c166999d1c6eb19a8b25446dde5036628L99-R103): Modified the `buyTool` definition to use `useFGA` directly and restructured the function to improve clarity and functionality. [[1]](diffhunk://#diff-8fb1cf4cde044d4166b3bda4d69c651c166999d1c6eb19a8b25446dde5036628L99-R103) [[2]](diffhunk://#diff-8fb1cf4cde044d4166b3bda4d69c651c166999d1c6eb19a8b25446dde5036628R112)