### PR TITLE
chore(dep): update vite dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@openfga/sdk": "^0.8.0",
-        "vite": "^6.2.1"
+        "vite": "^6.2.3"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^19.8.0",
@@ -23832,9 +23832,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -24470,7 +24470,7 @@
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0",
-        "vitest": "^3.0.8"
+        "vitest": "^3.0.9"
       }
     },
     "packages/ai-components": {
@@ -24514,7 +24514,7 @@
         "eslint": "^9.22.0",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
-        "vitest": "^3.0.8"
+        "vitest": "^3.0.9"
       },
       "peerDependencies": {
         "@openfga/sdk": "^0.8.0"
@@ -24772,7 +24772,7 @@
         "eslint": "^9.22.0",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
-        "vitest": "^3.0.8"
+        "vitest": "^3.0.9"
       },
       "peerDependencies": {
         "@langchain/core": "^0.3.19",
@@ -25037,7 +25037,7 @@
         "eslint": "^9.22.0",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
-        "vitest": "^3.0.8"
+        "vitest": "^3.0.9"
       },
       "peerDependencies": {
         "@openfga/sdk": "^0.8.0"
@@ -25296,7 +25296,7 @@
         "eslint": "^9.22.0",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
-        "vitest": "^3.0.8"
+        "vitest": "^3.0.9"
       },
       "peerDependencies": {
         "ai": "^4.1.54",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   ],
   "dependencies": {
     "@openfga/sdk": "^0.8.0",
-    "vite": "^6.2.1"
+    "vite": "^6.2.3"
   }
 }

--- a/packages/ai-genkit/package.json
+++ b/packages/ai-genkit/package.json
@@ -45,7 +45,7 @@
     "eslint": "^9.22.0",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.8"
+    "vitest": "^3.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai-langchain/package.json
+++ b/packages/ai-langchain/package.json
@@ -54,7 +54,7 @@
     "eslint": "^9.22.0",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.8"
+    "vitest": "^3.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai-llamaindex/package.json
+++ b/packages/ai-llamaindex/package.json
@@ -48,7 +48,7 @@
     "eslint": "^9.22.0",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.8"
+    "vitest": "^3.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai-vercel/package.json
+++ b/packages/ai-vercel/package.json
@@ -64,7 +64,7 @@
     "eslint": "^9.22.0",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.8"
+    "vitest": "^3.0.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -60,7 +60,7 @@
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0",
-    "vitest": "^3.0.8"
+    "vitest": "^3.0.9"
   },
   "dependencies": {
     "@openfga/sdk": "^0.8.0",


### PR DESCRIPTION
This pull request includes updates to several package dependencies across multiple files. The most important changes involve updating the versions of `vite` and `vitest` dependencies.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R34): Updated `vite` dependency from version `^6.2.1` to `^6.2.3`.
* `packages/ai-genkit/package.json`, `packages/ai-langchain/package.json`, `packages/ai-llamaindex/package.json`, `packages/ai-vercel/package.json`, `packages/ai/package.json`: Updated `vitest` dependency from version `^3.0.8` to `^3.0.9`. [[1]](diffhunk://#diff-c6a418b63601c8cd1ebb9280658c36c7afce12b9a7444a40705de54d18c1c983L48-R48) [[2]](diffhunk://#diff-2d0aede74b38e61ff841e237af368e676506ebaf46f123bbe7ed389a86df0bd6L57-R57) [[3]](diffhunk://#diff-a88e0376c9b2001bd301cbaf4fc59baa622a0ec2dce294f0cd4131946af5b5c2L51-R51) [[4]](diffhunk://#diff-58aa606e03887c81c436e799d7cb8d4a0c422a590d7222c9905188dde4cd5afcL67-R67) [[5]](diffhunk://#diff-3758ea4fd63e4789bf712baab7b4b0227fce843a17e2ed535091b9c3b83ff2dfL63-R63)