### PR TITLE
fix(ai): ensure interrupt isn't falsy in isInterrupt

### DIFF
--- a/packages/ai/src/interrupts/Auth0Interrupt.ts
+++ b/packages/ai/src/interrupts/Auth0Interrupt.ts
@@ -54,6 +54,7 @@ export class Auth0Interrupt extends Error {
     interrupt: any
   ): interrupt is Auth0InterruptData<InstanceType<T>> {
     return (
+      interrupt &&
       interrupt.name === "AUTH0_AI_INTERRUPT" &&
       (typeof this.code === "undefined" || interrupt.code === this.code)
     );


### PR DESCRIPTION
This prevents errors when calling `FederatedConnectionInterrupt.isInterrupt(toolInterrupt)` such as when calling the weather tool in the nextjs-ai demo:

<img width="890" alt="Screenshot 2025-03-27 at 10 04 42 pm" src="https://github.com/user-attachments/assets/f856adaf-b7e1-45af-943e-d539d3a92aff" />
