### PR TITLE
fix(ai-vercel): ensure Auth0Interrupt errors get serialized

### DIFF
--- a/packages/ai-vercel/src/interrupts/errorSerializer.ts
+++ b/packages/ai-vercel/src/interrupts/errorSerializer.ts
@@ -19,7 +19,6 @@ export const errorSerializer = (errHandler?: errorHandler): errorHandler => {
   return (error: any) => {
     if (
       !(error instanceof ToolExecutionError) ||
-      error.cause ||
       !(error.cause instanceof Auth0Interrupt)
     ) {
       if (errHandler) {


### PR DESCRIPTION
The previous `error.cause` check here was inverted and prevented `Auth0Interrupt` errors from being serialized correctly (and therefore not interrupted).

The logic could be changed to include `!error.cause`, but that's not necessary as `error.cause instanceof Auth0Interrupt` covers that case already (and won't error if error.cause is undefined)

This matches the same logic used elsewhere, eg: https://github.com/auth0-lab/auth0-ai-js/blob/ceaabea989ef7aebfaef1db6f895f053307901d1/packages/ai-vercel/src/interrupts/util.ts#L31-L37