### PR TITLE
fix(genkit/fga): execute fn is never called

### DIFF
--- a/packages/ai-genkit/src/FGA/FGAAuthorizer.ts
+++ b/packages/ai-genkit/src/FGA/FGAAuthorizer.ts
@@ -3,7 +3,7 @@ import { GenkitBeta } from "genkit/beta";
 import { FGAAuthorizerBase } from "@auth0/ai/FGA";
 import { ToolFnOptions, ToolRunOptions } from "@genkit-ai/ai/tool";
 
-import { createToolWrapper, ToolWrapper } from "../lib";
+import { ToolWrapper } from "../lib";
 
 /**
  * The FGAAuthorizer class implements the FGA authorization control for a Genkit AI tool.
@@ -29,6 +29,8 @@ export class FGAAuthorizer extends FGAAuthorizerBase<
    * @returns A tool authorizer.
    */
   authorizer(): ToolWrapper {
-    return createToolWrapper(this.genkit, this.protect.bind(this));
+    return (toolMeta, toolFunc) => {
+      return [toolMeta, this.protect(toolFunc)];
+    };
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `FGAAuthorizer` class in the `packages/ai-genkit/src/FGA/FGAAuthorizer.ts` file to simplify the code and improve maintainability.

Code simplification:

* [`packages/ai-genkit/src/FGA/FGAAuthorizer.ts`](diffhunk://#diff-6919fa3301b57265b62f1a39d60d389b474b126c7b1f4c16bccda0b67c22b46fL6-R6): Removed the `createToolWrapper` import and updated the `authorizer` method to directly return a function that wraps the tool metadata and function with the `protect` method. [[1]](diffhunk://#diff-6919fa3301b57265b62f1a39d60d389b474b126c7b1f4c16bccda0b67c22b46fL6-R6) [[2]](diffhunk://#diff-6919fa3301b57265b62f1a39d60d389b474b126c7b1f4c16bccda0b67c22b46fL32-R34)