### PR TITLE
fix: withFGA for llamaindex

### DIFF
--- a/packages/ai-llamaindex/src/FGA/FGAAuthorizer.ts
+++ b/packages/ai-llamaindex/src/FGA/FGAAuthorizer.ts
@@ -1,8 +1,6 @@
-import { JSONValue } from "llamaindex";
+import { FunctionTool, JSONValue } from "llamaindex";
 
 import { FGAAuthorizerBase } from "@auth0/ai/FGA";
-
-import { createToolWrapper } from "../lib";
 
 export type LlamaToolHandler<T> = (input: T) => JSONValue | Promise<JSONValue>;
 
@@ -23,6 +21,14 @@ export class FGAAuthorizer extends FGAAuthorizerBase<
    * @returns A tool authorizer.
    */
   authorizer() {
-    return createToolWrapper(this.protect.bind(this));
+    return <
+      T,
+      R extends JSONValue | Promise<JSONValue>,
+      AdditionalToolArgument extends object = object,
+    >(
+      t: FunctionTool<T, R, AdditionalToolArgument>
+    ) => {
+      return FunctionTool.from(this.protect(t.call), t.metadata);
+    };
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `FGAAuthorizer` class in the `packages/ai-llamaindex/src/FGA/FGAAuthorizer.ts` file. The main updates involve the import statements and the `authorizer` method.

### Import statement updates:
* Added `FunctionTool` to the import statement from `llamaindex`.

### `authorizer` method updates:
* Replaced the `createToolWrapper` function call with a new implementation that uses `FunctionTool` to create a tool authorizer. This change includes the addition of type parameters and a new method call structure.