### PR TITLE
feat(ai-components): allow containerClassName on EnsureAPIAccess component for styling

### DIFF
--- a/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/FederatedConnectionAuthProps.tsx
+++ b/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/FederatedConnectionAuthProps.tsx
@@ -21,6 +21,7 @@ export type FederatedConnectionAuthProps = {
     title: string;
     description: string;
     action?: { label: string };
+    containerClassName?: string;
   };
   mode?: AuthComponentMode;
 };

--- a/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/popup.tsx
+++ b/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/popup.tsx
@@ -8,7 +8,7 @@ import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 
 export function EnsureAPIAccessPopup({
   interrupt: { connection, requiredScopes, resume },
-  connectWidget: { icon, title, description, action },
+  connectWidget: { icon, title, description, action, containerClassName },
   onFinish,
 }: FederatedConnectionAuthProps) {
   const [isLoading, setIsLoading] = useState(false);
@@ -70,6 +70,7 @@ export function EnsureAPIAccessPopup({
       title={title}
       description={description}
       icon={icon}
+      containerClassName={containerClassName}
       action={{
         label: action?.label ?? "Connect",
         onClick: startLoginPopup,

--- a/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/redirect.tsx
+++ b/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/redirect.tsx
@@ -6,13 +6,14 @@ import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 export function EnsureAPIAccessRedirect({
   connection,
   scopes,
-  connectWidget: { icon, title, description, action },
+  connectWidget: { icon, title, description, action, containerClassName },
 }: FederatedConnectionAuthProps) {
   return (
     <PromptUserContainer
       title={title}
       description={description}
       icon={icon}
+      containerClassName={containerClassName}
       action={{
         label: action?.label ?? "Connect",
         onClick: () => {

--- a/packages/ai-components/templates/FederatedConnections/FederatedConnectionAuthProps.tsx
+++ b/packages/ai-components/templates/FederatedConnections/FederatedConnectionAuthProps.tsx
@@ -21,6 +21,7 @@ export type FederatedConnectionAuthProps = {
     title: string;
     description: string;
     action?: { label: string };
+    containerClassName?: string;
   };
   mode?: AuthComponentMode;
 };

--- a/packages/ai-components/templates/FederatedConnections/popup.tsx
+++ b/packages/ai-components/templates/FederatedConnections/popup.tsx
@@ -8,7 +8,7 @@ import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 
 export function EnsureAPIAccessPopup({
   interrupt: { connection, requiredScopes, resume },
-  connectWidget: { icon, title, description, action },
+  connectWidget: { icon, title, description, action, containerClassName },
   onFinish,
 }: FederatedConnectionAuthProps) {
   const [isLoading, setIsLoading] = useState(false);
@@ -70,6 +70,7 @@ export function EnsureAPIAccessPopup({
       title={title}
       description={description}
       icon={icon}
+      containerClassName={containerClassName}
       action={{
         label: action?.label ?? "Connect",
         onClick: startLoginPopup,

--- a/packages/ai-components/templates/FederatedConnections/redirect.tsx
+++ b/packages/ai-components/templates/FederatedConnections/redirect.tsx
@@ -6,13 +6,14 @@ import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 export function EnsureAPIAccessRedirect({
   connection,
   scopes,
-  connectWidget: { icon, title, description, action },
+  connectWidget: { icon, title, description, action, containerClassName },
 }: FederatedConnectionAuthProps) {
   return (
     <PromptUserContainer
       title={title}
       description={description}
       icon={icon}
+      containerClassName={containerClassName}
       action={{
         label: action?.label ?? "Connect",
         onClick: () => {


### PR DESCRIPTION
This pull request introduces a new optional property, `containerClassName`, to the `FederatedConnectionAuthProps` type and updates its usage across multiple files. This change allows for additional customization of the container's CSS class.

### Addition of `containerClassName` property:

* [`examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/FederatedConnectionAuthProps.tsx`](diffhunk://#diff-4f3834a498cb5214c30eda5b899dae9f2daa2c98de76699e8d4685dabc47963aR21): Added `containerClassName` to the `FederatedConnectionAuthProps` type.
* [`packages/ai-components/templates/FederatedConnections/FederatedConnectionAuthProps.tsx`](diffhunk://#diff-4f3834a498cb5214c30eda5b899dae9f2daa2c98de76699e8d4685dabc47963aR21): Added `containerClassName` to the `FederatedConnectionAuthProps` type.

### Updates to components to utilize `containerClassName`:

* [`examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/popup.tsx`](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dL12-R12): Passed `containerClassName` to the `EnsureAPIAccessPopup` component. [[1]](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dL12-R12) [[2]](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dR72)
* [`examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/redirect.tsx`](diffhunk://#diff-63a61a5bd2e5d919159130781e62f01d3482e818fe8019448c8f817ab5c7d940L9-R16): Passed `containerClassName` to the `EnsureAPIAccessRedirect` component.
* [`packages/ai-components/templates/FederatedConnections/popup.tsx`](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dL12-R12): Passed `containerClassName` to the `EnsureAPIAccessPopup` component. [[1]](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dL12-R12) [[2]](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dR72)
* [`packages/ai-components/templates/FederatedConnections/redirect.tsx`](diffhunk://#diff-63a61a5bd2e5d919159130781e62f01d3482e818fe8019448c8f817ab5c7d940L9-R16): Passed `containerClassName` to the `EnsureAPIAccessRedirect` component.