### PR TITLE
fix: fix isInterrupt for ciba and device flow

### DIFF
--- a/packages/ai-langchain/src/ciba/GraphResumer.ts
+++ b/packages/ai-langchain/src/ciba/GraphResumer.ts
@@ -108,7 +108,7 @@ export class GraphResumer extends EventEmitter<Events> {
     for (const thread of allThreads) {
       const interrupt = getAuth0Interrupts(thread).find(
         (i) =>
-          AuthorizationPendingInterrupt.isInterrupt(i.value) &&
+          AuthorizationPendingInterrupt.isInterrupt(i.value) ||
           AuthorizationPollingInterrupt.isInterrupt(i.value)
       ) as Interrupt<
         AuthorizationPendingInterrupt | AuthorizationPollingInterrupt

--- a/packages/ai/src/interrupts/CIBAInterrupts.ts
+++ b/packages/ai/src/interrupts/CIBAInterrupts.ts
@@ -14,14 +14,15 @@ export class CIBAInterrupt extends Auth0Interrupt {
   }
 
   static isInterrupt<T extends abstract new (...args: any) => any>(
-    this: T,
+    this: T & { code?: string },
     interrupt: any
   ): interrupt is Auth0InterruptData<InstanceType<T>> {
     return (
       interrupt &&
       Auth0Interrupt.isInterrupt(interrupt) &&
       typeof interrupt.code === "string" &&
-      interrupt.code.startsWith("CIBA_")
+      (this.code === interrupt.code ||
+        (!this.code && interrupt.code.startsWith("CIBA_")))
     );
   }
 
@@ -94,7 +95,7 @@ export class AuthorizationPendingInterrupt
  * An interrupt that is thrown when the authorization polling fails.
  */
 export class AuthorizationPollingInterrupt
-  extends Auth0Interrupt
+  extends CIBAInterrupt
   implements WithRequestData
 {
   public static code: string = "CIBA_AUTHORIZATION_POLLING_ERROR" as const;
@@ -110,7 +111,7 @@ export class AuthorizationPollingInterrupt
  * An interrupt that is thrown when the authorization polling fails.
  */
 export class InvalidGrantInterrupt
-  extends Auth0Interrupt
+  extends CIBAInterrupt
   implements WithRequestData
 {
   public static code: string = "CIBA_INVALID_GRANT" as const;

--- a/packages/ai/src/interrupts/DeviceInterrupts.ts
+++ b/packages/ai/src/interrupts/DeviceInterrupts.ts
@@ -14,14 +14,15 @@ export class DeviceInterrupt extends Auth0Interrupt {
   }
 
   static isInterrupt<T extends abstract new (...args: any) => any>(
-    this: T,
+    this: T & { code?: string },
     interrupt: any
   ): interrupt is Auth0InterruptData<InstanceType<T>> {
     return (
       interrupt &&
       Auth0Interrupt.isInterrupt(interrupt) &&
       typeof interrupt.code === "string" &&
-      interrupt.code.startsWith("DEVICE_")
+      (this.code === interrupt.code ||
+        (!this.code && interrupt.code.startsWith("DEVICE_")))
     );
   }
 

--- a/packages/ai/test/ciba/interrupt.test.ts
+++ b/packages/ai/test/ciba/interrupt.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AuthorizationPendingInterrupt,
+  AuthorizationPollingInterrupt,
+  CIBAInterrupt,
+} from "../../src/interrupts/CIBAInterrupts";
+
+describe("CIBA Interrupts", () => {
+  it("isInterrupt should properly work", () => {
+    const interrupt = new AuthorizationPendingInterrupt("test", {
+      id: "123",
+      requestedAt: Date.now(),
+      expiresIn: Date.now() + 1000,
+      interval: 300,
+    });
+    expect(CIBAInterrupt.isInterrupt(interrupt)).toBe(true);
+    expect(AuthorizationPendingInterrupt.isInterrupt(interrupt)).toBe(true);
+    expect(AuthorizationPollingInterrupt.isInterrupt(interrupt)).toBe(false);
+  });
+});


### PR DESCRIPTION
This pull request includes changes to improve the handling of interrupts in the `ai-langchain` and `ai` packages. The most significant changes involve updating the interrupt classes to use a more flexible type checking mechanism and adding new tests to ensure functionality.

### Improvements to interrupt handling:

* [`packages/ai-langchain/src/ciba/GraphResumer.ts`](diffhunk://#diff-d5544aa49efeb05c036aaff25adf1e047dc37ab7659be8f6d01427ac4bbf3be5L111-R111): Modified the interrupt check to include `AuthorizationPollingInterrupt` alongside `AuthorizationPendingInterrupt`.

* [`packages/ai/src/interrupts/CIBAInterrupts.ts`](diffhunk://#diff-c50ea2e6eab96e9cd1b9966335476ca8735376cc34949debd7ae5a41e4576f55L17-R25): Updated the `isInterrupt` method in `CIBAInterrupt` to allow for more flexible type checking by including an optional `code` property.

### Refactoring of interrupt classes:

* [`packages/ai/src/interrupts/CIBAInterrupts.ts`](diffhunk://#diff-c50ea2e6eab96e9cd1b9966335476ca8735376cc34949debd7ae5a41e4576f55L97-R98): Changed `AuthorizationPollingInterrupt` and `InvalidGrantInterrupt` to extend from `CIBAInterrupt` instead of `Auth0Interrupt` for consistency. [[1]](diffhunk://#diff-c50ea2e6eab96e9cd1b9966335476ca8735376cc34949debd7ae5a41e4576f55L97-R98) [[2]](diffhunk://#diff-c50ea2e6eab96e9cd1b9966335476ca8735376cc34949debd7ae5a41e4576f55L113-R114)

* [`packages/ai/src/interrupts/DeviceInterrupts.ts`](diffhunk://#diff-7215f700688a364fc29f3d5690a86be76e2b7982ae0882877047edd2d81ec25eL17-R25): Updated the `isInterrupt` method in `DeviceInterrupt` to include an optional `code` property for more flexible type checking.

### Addition of tests:

* [`packages/ai/test/ciba/interrupt.test.ts`](diffhunk://#diff-a167f2d9d4f50ee62068d133176dbc48b60004ec2b7fe202ea06edc448925c59R1-R21): Added new tests to verify the functionality of the `isInterrupt` method for `CIBAInterrupt`, `AuthorizationPendingInterrupt`, and `AuthorizationPollingInterrupt`.