### PR TITLE
chore(docs): typos on readme and tiny improvements

### DIFF
--- a/examples/async-user-confirmation/langgraph/README.md
+++ b/examples/async-user-confirmation/langgraph/README.md
@@ -66,10 +66,10 @@ LANGGRAPH_API_URL="http://localhost:54367"
 
 The command `npm run dev` runs several process in parallel. Here is an explanation of each one:
 
-- **LangGraph**: The LangGraph server that will be run the graphs.
-- **Scheduler**: This is a demo scheduler that works similar to [LangGraph Cron Jobs](https://langchain-ai.github.io/langgraph/cloud/how-tos/cron_jobs/).
-- **API**: An API that is used in the demo that requires certain level of authorization.
-- **GraphResumer**: A service that try to resume CIBA-interrupted graphs in the LangGraph server.
+- **LangGraph**: The server responsible for executing and managing LangGraph-based graphs.
+- **Scheduler**: A demo scheduler that replicates the behavior of [LangGraph Cron Jobs](https://langchain-ai.github.io/langgraph/cloud/how-tos/cron_jobs/).
+- **API**: A demo API with endpoints that require specific authorization levels.
+- **GraphResumer**: A service that attempts to resume threads interrupted during CIBA flows on the LangGraph server.
 
 ### Diagram
 

--- a/examples/calling-apis/chatbot/README.md
+++ b/examples/calling-apis/chatbot/README.md
@@ -50,7 +50,7 @@ npm run dev
 This will start the development server at [http://localhost:3000](http://localhost:3000). You can open the URL with your browser to try the application.
 
 > [!NOTE]
-> For the [Langgraph example](/examples/calling-apis/chatbot/app/(langgraph)/)) to work, it's necessary to run a local Langgraph server with the following command:
+> For the [Langgraph example](/examples/calling-apis/chatbot/app/(langgraph)/) to work, it's necessary to run a local Langgraph server with the following command:
 > ```bash
 > npm run langgraph:dev
 > ```

--- a/examples/calling-apis/chatbot/app/(langgraph)/README.md
+++ b/examples/calling-apis/chatbot/app/(langgraph)/README.md
@@ -3,7 +3,8 @@
 This example demonstrates how to integrate **Auth0 AI SDK** with **LangGraph** to call APIs on user's behalf. It showcases the process of obtaining user authorization and calling an external API using the LangGraph framework.
 
 > [!WARNING]
-> For this example to work as expected you need to run a local LangGraph server. You can do this by running the following command:
+> For this example to work as expected you need to run a local LangGraph server. You can do this by running the following command from the [/examples/calling-apis/chatbot](/examples/calling-apis/chatbot/) path:
+>
 > ```bash
 > npm run langgraph:dev
 > ```

--- a/examples/device-flow/langgraph/README.md
+++ b/examples/device-flow/langgraph/README.md
@@ -65,10 +65,10 @@ LANGGRAPH_API_URL="http://localhost:54367"
 
 The command `npm run dev` runs several process in parallel. Here is an explanation of each one:
 
-- **LangGraph**: The LangGraph server that will be run the graphs.
-- **Scheduler**: This is a demo scheduler that works similar to [LangGraph Cron Jobs](https://langchain-ai.github.io/langgraph/cloud/how-tos/cron_jobs/).
-- **API**: An API that is used in the demo that requires certain level of authorization.
-- **GraphResumer**: A service that try to resume CIBA-interrupted graphs in the LangGraph server.
+- **LangGraph**: The server responsible for executing and managing LangGraph-based graphs.
+- **Scheduler**: A demo scheduler that replicates the behavior of [LangGraph Cron Jobs](https://langchain-ai.github.io/langgraph/cloud/how-tos/cron_jobs/).
+- **API**: A demo API with endpoints that require specific authorization levels.
+- **GraphResumer**: A service that attempts to resume threads interrupted during CIBA flows on the LangGraph server.
 
 ### Diagram
 


### PR DESCRIPTION
This pull request includes several updates to the README files in different examples to improve clarity and accuracy. The changes primarily focus on refining descriptions and instructions related to the LangGraph server and its components.

Improvements to README descriptions and instructions:

* [`examples/async-user-confirmation/langgraph/README.md`](diffhunk://#diff-2d2db2dee3686937c8701ce30cc82f48f4114fa6b9c3a17b8c3fc9dca46ebe35L69-R72): Updated descriptions for LangGraph server components to be more precise and clear.
* [`examples/device-flow/langgraph/README.md`](diffhunk://#diff-55f59e7e6da80c6702c8115336923b03866e776a4dcc3667f71c0078957a4051L68-R71): Similar updates to descriptions for LangGraph server components, ensuring consistency and clarity.
* [`examples/calling-apis/chatbot/README.md`](diffhunk://#diff-3a2795dccc693717aac3dd5b9a1ece163943f749eba297acac94ba1988fe99f3L53-R53): Fixed a typo in the path for the LangGraph example.
* [`examples/calling-apis/chatbot/app/(langgraph)/README.md`](diffhunk://#diff-d5215de9b94d116253f5ee1ee67805c7f3c5198fd2be9da94e0d22ea7d1e8e9dL6-R7): Added a note specifying the correct path to run the LangGraph server command.