### PR TITLE
fix: rename getAccessTokenForConnection to getCredentialsForConnection

### DIFF
--- a/examples/calling-apis/chatbot/app/(ai-sdk)/lib/tools/check-user-calendar.ts
+++ b/examples/calling-apis/chatbot/app/(ai-sdk)/lib/tools/check-user-calendar.ts
@@ -17,7 +17,7 @@ export const checkUsersCalendar = withGoogleCalendar(
     }),
     execute: async ({ date }) => {
       // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
+      const accessToken = getAccessTokenForConnection();
 
       // Google SDK
       try {
@@ -25,7 +25,7 @@ export const checkUsersCalendar = withGoogleCalendar(
         const auth = new google.auth.OAuth2();
 
         auth.setCredentials({
-          access_token: credentials?.accessToken,
+          access_token: accessToken,
         });
 
         const response = await calendar.freebusy.query({

--- a/examples/calling-apis/chatbot/app/(ai-sdk)/lib/tools/google-drive-tools.ts
+++ b/examples/calling-apis/chatbot/app/(ai-sdk)/lib/tools/google-drive-tools.ts
@@ -22,10 +22,10 @@ export const googleDriveTools = Object.fromEntries(
           : jsonSchema(asAgenticSchema(fn.inputSchema).jsonSchema),
         execute: async (args) => {
           // Get the access token from Auth0 AI
-          const credentials = getAccessTokenForConnection();
+          const accessToken = getAccessTokenForConnection();
 
           auth.setCredentials({
-            access_token: credentials?.accessToken,
+            access_token: accessToken,
           });
 
           // Execute Google Drive function from `@agentic`

--- a/examples/calling-apis/chatbot/app/(ai-sdk)/lib/tools/list-channels.ts
+++ b/examples/calling-apis/chatbot/app/(ai-sdk)/lib/tools/list-channels.ts
@@ -12,11 +12,11 @@ export const listChannels = withSlack(
     parameters: z.object({}),
     execute: async () => {
       // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
+      const accessToken = getAccessTokenForConnection();
 
       // Slack SDK
       try {
-        const web = new WebClient(credentials?.accessToken);
+        const web = new WebClient(accessToken);
 
         const result = await web.conversations.list({
           exclude_archived: true,

--- a/examples/calling-apis/chatbot/app/(ai-sdk)/lib/tools/list-repositories.ts
+++ b/examples/calling-apis/chatbot/app/(ai-sdk)/lib/tools/list-repositories.ts
@@ -12,12 +12,12 @@ export const listRepositories = withGitHub(
     parameters: z.object({}),
     execute: async () => {
       // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
+      const accessToken = getAccessTokenForConnection();
 
       // GitHub SDK
       try {
         const octokit = new Octokit({
-          auth: credentials?.accessToken,
+          auth: accessToken,
         });
         const { data } = await octokit.rest.repos.listForAuthenticatedUser();
 

--- a/examples/calling-apis/chatbot/app/(genkit)/lib/tools/check-user-calendar.ts
+++ b/examples/calling-apis/chatbot/app/(genkit)/lib/tools/check-user-calendar.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { withTokenForGoogleConnection } from "@/app/(genkit)/lib/auth0-ai";
 import { ai } from "@/app/(genkit)/lib/genkit";
-import { getAccessTokenForConnection } from "@auth0/ai-genkit";
+import { getCredentialsForConnection } from "@auth0/ai-genkit";
 import { FederatedConnectionError } from "@auth0/ai/interrupts";
 
 export const checkUsersCalendar = ai.defineTool(
@@ -25,7 +25,7 @@ export const checkUsersCalendar = ai.defineTool(
     },
     async ({ date }) => {
       // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
+      const credentials = getCredentialsForConnection();
 
       // Google SDK
       try {

--- a/examples/calling-apis/chatbot/app/(genkit)/lib/tools/list-channels.ts
+++ b/examples/calling-apis/chatbot/app/(genkit)/lib/tools/list-channels.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { withSlack } from "@/app/(genkit)/lib/auth0-ai";
 import { ai } from "@/app/(genkit)/lib/genkit";
-import { getAccessTokenForConnection } from "@auth0/ai-genkit";
+import { getCredentialsForConnection } from "@auth0/ai-genkit";
 import { FederatedConnectionError } from "@auth0/ai/interrupts";
 import { ErrorCode, WebClient } from "@slack/web-api";
 
@@ -15,7 +15,7 @@ export const listChannels = ai.defineTool(
     },
     async () => {
       // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
+      const credentials = getCredentialsForConnection();
 
       // Slack SDK
       try {

--- a/examples/calling-apis/chatbot/app/(genkit)/lib/tools/list-repositories.ts
+++ b/examples/calling-apis/chatbot/app/(genkit)/lib/tools/list-repositories.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { withGitHub } from "@/app/(genkit)/lib/auth0-ai";
 import { ai } from "@/app/(genkit)/lib/genkit";
-import { getAccessTokenForConnection } from "@auth0/ai-genkit";
+import { getCredentialsForConnection } from "@auth0/ai-genkit";
 import { FederatedConnectionError } from "@auth0/ai/interrupts";
 
 export const listRepositories = ai.defineTool(
@@ -15,7 +15,7 @@ export const listRepositories = ai.defineTool(
     },
     async () => {
       // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
+      const credentials = getCredentialsForConnection();
 
       // GitHub SDK
       try {

--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/calendar-view-tool.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/calendar-view-tool.ts
@@ -12,11 +12,7 @@ const model = new ChatOpenAI({
 export const calendarCommunityTool = withGoogleCalendarCommunity(
   new GoogleCalendarViewTool({
     credentials: {
-      accessToken: async () => {
-        const credentials = getAccessTokenForConnection();
-        // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-        return credentials?.accessToken!;
-      },
+      accessToken: async () => getAccessTokenForConnection(),
       calendarId: "primary",
     },
     model,

--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/check-user-calendar.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/check-user-calendar.ts
@@ -12,16 +12,15 @@ import { withGoogleCalendar } from "../auth0-ai";
 export const checkUsersCalendar = withGoogleCalendar(
   tool(
     async ({ date }) => {
-      // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
-
       // Google SDK
       try {
+        const accessToken = getAccessTokenForConnection();
+
         const calendar = google.calendar("v3");
         const auth = new google.auth.OAuth2();
 
         auth.setCredentials({
-          access_token: credentials?.accessToken,
+          access_token: accessToken,
         });
 
         const response = await calendar.freebusy.query({

--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/gmail-search.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/gmail-search.ts
@@ -6,14 +6,7 @@ import { withGmailCommunity } from "../../lib/auth0-ai";
 export const gmailCommunityTool = withGmailCommunity(
   new GmailSearch({
     credentials: {
-      accessToken: async () => {
-        const credentials = getAccessTokenForConnection();
-        const accessToken = credentials?.accessToken;
-        if (!accessToken) {
-          throw new Error("No access token found");
-        }
-        return accessToken;
-      },
+      accessToken: async () => getAccessTokenForConnection(),
     },
   })
 );

--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/list-channels.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/list-channels.ts
@@ -11,11 +11,11 @@ export const listChannels = withSlack(
   tool(
     async () => {
       // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
+      const accessToken = getAccessTokenForConnection();
 
       // Slack SDK
       try {
-        const web = new WebClient(credentials?.accessToken);
+        const web = new WebClient(accessToken);
 
         const result = await web.conversations.list({
           exclude_archived: true,

--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/list-repositories.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/list-repositories.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { getAccessTokenForConnection } from "@auth0/ai-langchain";
+import { getCredentialsForConnection } from "@auth0/ai-langchain";
 import { FederatedConnectionError } from "@auth0/ai/interrupts";
 import { tool } from "@langchain/core/tools";
 import { RequestError } from "@octokit/request-error";
@@ -12,12 +12,12 @@ export const listRepositories = withGitHub(
   tool(
     async () => {
       // Get the access token from Auth0 AI
-      const credentials = getAccessTokenForConnection();
+      const accessToken = getCredentialsForConnection();
 
       // GitHub SDK
       try {
         const octokit = new Octokit({
-          auth: credentials?.accessToken,
+          auth: accessToken,
         });
 
         const { data } = await octokit.rest.repos.listForAuthenticatedUser();

--- a/examples/calling-apis/chatbot/app/(llamaindex)/lib/tools/check-user-calendar.ts
+++ b/examples/calling-apis/chatbot/app/(llamaindex)/lib/tools/check-user-calendar.ts
@@ -5,7 +5,7 @@ import { tool } from "llamaindex";
 import { z } from "zod";
 
 import { withGoogleCalendar } from "@/app/(llamaindex)/lib/auth0-ai";
-import { getAccessTokenForConnection } from "@auth0/ai-llamaindex";
+import { getCredentialsForConnection } from "@auth0/ai-llamaindex";
 import { FederatedConnectionError } from "@auth0/ai/interrupts";
 
 export const checkUsersCalendar = () =>
@@ -13,7 +13,7 @@ export const checkUsersCalendar = () =>
     tool(
       async ({ date }) => {
         // Get the access token from Auth0 AI
-        const credentials = getAccessTokenForConnection();
+        const credentials = getCredentialsForConnection();
 
         // Google SDK
         try {

--- a/examples/calling-apis/chatbot/app/(llamaindex)/lib/tools/list-channels.ts
+++ b/examples/calling-apis/chatbot/app/(llamaindex)/lib/tools/list-channels.ts
@@ -2,7 +2,7 @@ import { tool } from "llamaindex";
 import { z } from "zod";
 
 import { withSlack } from "@/app/(llamaindex)/lib/auth0-ai";
-import { getAccessTokenForConnection } from "@auth0/ai-llamaindex";
+import { getCredentialsForConnection } from "@auth0/ai-llamaindex";
 import { FederatedConnectionError } from "@auth0/ai/interrupts";
 import { ErrorCode, WebClient } from "@slack/web-api";
 
@@ -11,7 +11,7 @@ export const listChannels = () =>
     tool(
       async () => {
         // Get the access token from Auth0 AI
-        const credentials = getAccessTokenForConnection();
+        const credentials = getCredentialsForConnection();
 
         // Slack SDK
         try {

--- a/examples/calling-apis/chatbot/app/(llamaindex)/lib/tools/list-repositories.ts
+++ b/examples/calling-apis/chatbot/app/(llamaindex)/lib/tools/list-repositories.ts
@@ -3,7 +3,7 @@ import { Octokit, RequestError } from "octokit";
 import { z } from "zod";
 
 import { withGitHub } from "@/app/(llamaindex)/lib/auth0-ai";
-import { getAccessTokenForConnection } from "@auth0/ai-vercel";
+import { getCredentialsForConnection } from "@auth0/ai-vercel";
 import { FederatedConnectionError } from "@auth0/ai/interrupts";
 
 export const listRepositories = () =>
@@ -11,7 +11,7 @@ export const listRepositories = () =>
     tool(
       async () => {
         // Get the access token from Auth0 AI
-        const credentials = getAccessTokenForConnection();
+        const credentials = getCredentialsForConnection();
 
         // GitHub SDK
         try {

--- a/packages/ai-genkit/README.md
+++ b/packages/ai-genkit/README.md
@@ -95,7 +95,7 @@ export const checkCalendarTool = ai.defineTool(
     }),
   },
   async ({ date }) => {
-    const { accessToken } = getAccessTokenForConnection();
+    const accessToken = getAccessTokenForConnection();
     const body = JSON.stringify({
       timeMin: date,
       timeMax: addHours(date, 1),

--- a/packages/ai-genkit/src/FederatedConnections/index.ts
+++ b/packages/ai-genkit/src/FederatedConnections/index.ts
@@ -1,2 +1,5 @@
 export { FederatedConnectionAuthorizer } from "./FederatedConnectionAuthorizer";
-export { getAccessTokenForConnection } from "@auth0/ai/FederatedConnections";
+export {
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
+} from "@auth0/ai/FederatedConnections";

--- a/packages/ai-genkit/src/index.ts
+++ b/packages/ai-genkit/src/index.ts
@@ -3,4 +3,7 @@ export { FGAReranker, auth0 } from "./FGA/fga-reranker";
 export { getDeviceAuthorizerCredentials } from "./Device";
 export { getCIBACredentials } from "./CIBA";
 export { getAuth0Confirmations, resumeAuth0Interrupts } from "./lib";
-export { getAccessTokenForConnection } from "./FederatedConnections";
+export {
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
+} from "./FederatedConnections";

--- a/packages/ai-langchain/README.md
+++ b/packages/ai-langchain/README.md
@@ -79,7 +79,7 @@ import { addHours } from "date-fns";
 export const checkCalendarTool = withGoogleAccess(
   tool(
     async ({ date }) => {
-      const { accessToken } = getAccessTokenForConnection();
+      const accessToken = getAccessTokenForConnection();
       const body = JSON.stringify({
         timeMin: date,
         timeMax: addHours(date, 1),
@@ -151,10 +151,7 @@ import { withGmailCommunity } from "../../lib/auth0-ai";
 export const gmailCommunityTool = withGmailCommunity(
   new GmailSearch({
     credentials: {
-      accessToken: async () => {
-        const credentials = getAccessTokenForConnection();
-        return credentials?.accessToken!;
-      },
+      accessToken: async () => getAccessTokenForConnection(),
     },
   })
 );

--- a/packages/ai-langchain/src/FederatedConnections/index.ts
+++ b/packages/ai-langchain/src/FederatedConnections/index.ts
@@ -1,2 +1,5 @@
 export { FederatedConnectionAuthorizer } from "./FederatedConnectionAuthorizer";
-export { getAccessTokenForConnection } from "@auth0/ai/FederatedConnections";
+export {
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
+} from "@auth0/ai/FederatedConnections";

--- a/packages/ai-langchain/src/index.ts
+++ b/packages/ai-langchain/src/index.ts
@@ -1,7 +1,10 @@
 export { getAuth0Interrupts } from "./util/interrrupt";
 export { getCIBACredentials } from "./ciba";
 export { getDeviceAuthorizerCredentials } from "./Device";
-export { getAccessTokenForConnection } from "./FederatedConnections";
+export {
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
+} from "./FederatedConnections";
 export { GraphResumer } from "./ciba/GraphResumer";
 
 export { Auth0AI } from "./Auth0AI";

--- a/packages/ai-llamaindex/README.md
+++ b/packages/ai-llamaindex/README.md
@@ -86,7 +86,7 @@ import { addHours } from "date-fns";
 
 export const checkUsersCalendar = withGoogleAccess(
   tool(async ({ date }) => {
-    const { accessToken } = getAccessTokenForConnection();
+    const accessToken = getAccessTokenForConnection();
     const url = "https://www.googleapis.com/calendar/v3/freeBusy";
     const body = JSON.stringify({
       timeMin: date,

--- a/packages/ai-llamaindex/src/FederatedConnections/index.ts
+++ b/packages/ai-llamaindex/src/FederatedConnections/index.ts
@@ -1,2 +1,5 @@
 export { FederatedConnectionAuthorizer } from "./FederatedConnectionAuthorizer";
-export { getAccessTokenForConnection } from "@auth0/ai/FederatedConnections";
+export {
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
+} from "@auth0/ai/FederatedConnections";

--- a/packages/ai-llamaindex/src/index.ts
+++ b/packages/ai-llamaindex/src/index.ts
@@ -7,6 +7,9 @@ export { Auth0AI } from "./Auth0AI";
 
 export { getCIBACredentials } from "./CIBA";
 export { getDeviceAuthorizerCredentials } from "./Device";
-export { getAccessTokenForConnection } from "./FederatedConnections";
+export {
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
+} from "./FederatedConnections";
 
 export { setAIContext } from "./lib/index";

--- a/packages/ai-vercel/README.md
+++ b/packages/ai-vercel/README.md
@@ -90,7 +90,7 @@ export const checkUsersCalendar = withGoogleAccess(
       date: z.coerce.date(),
     }),
     execute: async ({ date }) => {
-      const { accessToken } = getAccessTokenForConnection();
+      const accessToken = getAccessTokenForConnection();
       const url = "https://www.googleapis.com/calendar/v3/freeBusy";
       const body = JSON.stringify({
         timeMin: date,

--- a/packages/ai-vercel/src/Auth0AI.ts
+++ b/packages/ai-vercel/src/Auth0AI.ts
@@ -6,9 +6,10 @@ import { CIBAAuthorizer } from "./CIBA";
 import { DeviceAuthorizer } from "./Device";
 import { FederatedConnectionAuthorizer } from "./FederatedConnections";
 import { FGA_AI } from "./FGA_AI";
+import { ToolWrapper } from "./util/ToolWrapper";
 
 import type { AuthorizerParams } from "@auth0/ai";
-type ToolWrapper = ReturnType<FederatedConnectionAuthorizer["authorizer"]>;
+
 type FederatedConnectionParams = Omit<
   ConstructorParameters<typeof FederatedConnectionAuthorizer>[1],
   "store"

--- a/packages/ai-vercel/src/CIBA/CIBAAuthorizer.ts
+++ b/packages/ai-vercel/src/CIBA/CIBAAuthorizer.ts
@@ -1,11 +1,9 @@
-import { Tool, ToolExecutionOptions } from "ai";
-import { Schema, z } from "zod";
+import { ToolExecutionOptions } from "ai";
 
 import { CIBAAuthorizerBase } from "@auth0/ai/CIBA";
 
 import { ToolContext } from "../util/ToolContext";
-
-type Parameters = z.ZodTypeAny | Schema<any>;
+import { ToolWrapper } from "../util/ToolWrapper";
 
 /**
  * The CIBAAuthorizer class implements the CIBA authorization flow for a Vercel-AI tool.
@@ -22,10 +20,8 @@ export class CIBAAuthorizer extends CIBAAuthorizerBase<
    *
    * @returns A tool authorizer.
    */
-  authorizer() {
-    return <PARAMETERS extends Parameters = any, RESULT = any>(
-      t: Tool<PARAMETERS, RESULT>
-    ): Tool<PARAMETERS, RESULT> => {
+  authorizer(): ToolWrapper {
+    return (t) => {
       return {
         ...t,
         execute: this.protect(ToolContext(t), t.execute!),

--- a/packages/ai-vercel/src/Device/DeviceAuthorizer.ts
+++ b/packages/ai-vercel/src/Device/DeviceAuthorizer.ts
@@ -1,11 +1,9 @@
-import { Tool, ToolExecutionOptions } from "ai";
-import { Schema, z } from "zod";
+import { ToolExecutionOptions } from "ai";
 
 import { DeviceAuthorizerBase } from "@auth0/ai/Device";
 
 import { ToolContext } from "../util/ToolContext";
-
-type Parameters = z.ZodTypeAny | Schema<any>;
+import { ToolWrapper } from "../util/ToolWrapper";
 
 /**
  * The DeviceAuthorizer class implements the Device Authorization Flow for a Vercel-AI tool.
@@ -19,10 +17,8 @@ export class DeviceAuthorizer extends DeviceAuthorizerBase<
    *
    * @returns A tool authorizer.
    */
-  authorizer() {
-    return <PARAMETERS extends Parameters = any, RESULT = any>(
-      t: Tool<PARAMETERS, RESULT>
-    ): Tool<PARAMETERS, RESULT> => {
+  authorizer(): ToolWrapper {
+    return (t) => {
       return {
         ...t,
         execute: this.protect(ToolContext(t), t.execute!),

--- a/packages/ai-vercel/src/FGA/FGAAuthorizer.ts
+++ b/packages/ai-vercel/src/FGA/FGAAuthorizer.ts
@@ -1,9 +1,8 @@
-import { Tool, ToolExecutionOptions } from "ai";
-import { Schema, z } from "zod";
+import { ToolExecutionOptions } from "ai";
 
 import { FGAAuthorizerBase } from "@auth0/ai/FGA";
 
-type Parameters = z.ZodTypeAny | Schema<any>;
+import { ToolWrapper } from "../util/ToolWrapper";
 
 /**
  * The FGAAuthorizer class implements the FGA authorization control for a Vercel AI tool.
@@ -21,10 +20,8 @@ export class FGAAuthorizer extends FGAAuthorizerBase<
    *
    * @returns A tool authorizer.
    */
-  authorizer() {
-    return <PARAMETERS extends Parameters = any, RESULT = any>(
-      t: Tool<PARAMETERS, RESULT>
-    ): Tool<PARAMETERS, RESULT> => {
+  authorizer(): ToolWrapper {
+    return (t) => {
       return {
         ...t,
         execute: this.protect(t.execute!),

--- a/packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts
+++ b/packages/ai-vercel/src/FederatedConnections/FederatedConnectionAuthorizer.ts
@@ -1,19 +1,15 @@
-import { Tool, ToolExecutionOptions } from "ai";
-import { Schema, z } from "zod";
+import { ToolExecutionOptions } from "ai";
 
 import { FederatedConnectionAuthorizerBase } from "@auth0/ai/FederatedConnections";
 
 import { ToolContext } from "../util/ToolContext";
-
-type Parameters = z.ZodTypeAny | Schema<any>;
+import { ToolWrapper } from "../util/ToolWrapper";
 
 export class FederatedConnectionAuthorizer extends FederatedConnectionAuthorizerBase<
   [any, ToolExecutionOptions]
 > {
-  authorizer() {
-    return <PARAMETERS extends Parameters = any, RESULT = any>(
-      t: Tool<PARAMETERS, RESULT>
-    ): Tool<PARAMETERS, RESULT> => {
+  authorizer(): ToolWrapper {
+    return (t) => {
       return {
         ...t,
         execute: this.protect(ToolContext(t), t.execute!),

--- a/packages/ai-vercel/src/FederatedConnections/index.ts
+++ b/packages/ai-vercel/src/FederatedConnections/index.ts
@@ -1,2 +1,5 @@
 export { FederatedConnectionAuthorizer } from "./FederatedConnectionAuthorizer";
-export { getAccessTokenForConnection } from "@auth0/ai/FederatedConnections";
+export {
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
+} from "@auth0/ai/FederatedConnections";

--- a/packages/ai-vercel/src/index.ts
+++ b/packages/ai-vercel/src/index.ts
@@ -2,6 +2,9 @@ export { Auth0AI } from "./Auth0AI";
 
 export { getCIBACredentials } from "./CIBA";
 export { getDeviceAuthorizerCredentials } from "./Device";
-export { getAccessTokenForConnection } from "./FederatedConnections";
+export {
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
+} from "./FederatedConnections";
 
 export { setAIContext, runWithAIContext } from "./context";

--- a/packages/ai-vercel/src/util/ToolWrapper.ts
+++ b/packages/ai-vercel/src/util/ToolWrapper.ts
@@ -1,0 +1,12 @@
+import { Tool } from "ai";
+import { Schema, z } from "zod";
+
+type Parameters = z.ZodTypeAny | Schema<any>;
+
+export type ToolWrapper = <
+  TParams extends Parameters = any,
+  TResult = any,
+  ToolType extends Tool<TParams, TResult> = Tool<TParams, TResult>,
+>(
+  t: ToolType
+) => ToolType;

--- a/packages/ai-vercel/test/FerderatedConnectionAuthorizer.test.ts
+++ b/packages/ai-vercel/test/FerderatedConnectionAuthorizer.test.ts
@@ -9,7 +9,7 @@ import { FederatedConnectionInterrupt } from "@auth0/ai/interrupts";
 import { setAIContext } from "../src/context";
 import {
   FederatedConnectionAuthorizer,
-  getAccessTokenForConnection,
+  getCredentialsForConnection,
 } from "../src/FederatedConnections";
 
 describe("FederatedConnectionAuthorizer", () => {
@@ -108,7 +108,7 @@ describe("FederatedConnectionAuthorizer", () => {
       try {
         setAIContext({ threadID: "123" });
         mockTool.execute.mockImplementation(() => {
-          const credentials = getAccessTokenForConnection();
+          const credentials = getCredentialsForConnection();
           accessToken = credentials?.accessToken;
           return { result: "success" };
         });

--- a/packages/ai/src/authorizers/federated-connections/asyncLocalStorage.ts
+++ b/packages/ai/src/authorizers/federated-connections/asyncLocalStorage.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 import { TokenSet } from "../../credentials";
+import { FederatedConnectionError } from "../../interrupts";
 import { ToolCallContext } from "../context";
 
 export type AsyncStorageValue = {
@@ -32,6 +33,13 @@ export type AsyncStorageValue = {
 
 export const asyncLocalStorage = new AsyncLocalStorage<AsyncStorageValue>();
 
+/**
+ * Returns the entire tokenset for the current connection.
+ *
+ * Use `getAccessTokenForConnection` if you only need the access token.
+ *
+ * @returns {TokenSet} The current token set.
+ */
 export const getCredentialsForConnection = () => {
   const store = asyncLocalStorage.getStore();
   if (typeof store === "undefined") {
@@ -40,4 +48,18 @@ export const getCredentialsForConnection = () => {
     );
   }
   return store?.credentials;
+};
+
+/**
+ *
+ * Get the access token for the current connection.
+ *
+ * @returns The access token for the current connection.
+ */
+export const getAccessTokenForConnection = () => {
+  const credentials = getCredentialsForConnection();
+  if (!credentials || !credentials.accessToken) {
+    throw new FederatedConnectionError("No credentials found");
+  }
+  return credentials.accessToken;
 };

--- a/packages/ai/src/authorizers/federated-connections/index.ts
+++ b/packages/ai/src/authorizers/federated-connections/index.ts
@@ -2,7 +2,8 @@ export type { AsyncStorageValue } from "./asyncLocalStorage";
 
 export {
   asyncLocalStorage,
-  getCredentialsForConnection as getAccessTokenForConnection,
+  getCredentialsForConnection,
+  getAccessTokenForConnection,
 } from "./asyncLocalStorage";
 
 export { FederatedConnectionAuthorizerBase } from "./FederatedConnectionAuthorizerBase";


### PR DESCRIPTION
- Now getAccessTokenForConnection returns the token (string) not the tokenset.
- `getCredentialsForConnection` returns the entire tokenset (expiration, claims, etc)
- Simplify the ToolWrapper interface for vercel-ai
