### PR TITLE
Improve components

### DIFF
--- a/packages/ai-components/bin/cli.js
+++ b/packages/ai-components/bin/cli.js
@@ -1,85 +1,113 @@
 #!/usr/bin/env node
-import { promises as fs } from 'fs';
-import path from 'path';
-import process from 'node:process';
+import { promises as fs } from "fs";
+import path from "path";
+import process from "node:process";
 
-const COMPONENTS_DIR = path.join(import.meta.dirname, '../templates');
-const TARGET_DIR = path.join(process.cwd(), 'components', 'auth0-ai');
+const COMPONENTS_DIR = path.join(import.meta.dirname, "../templates");
 
+const componentLocations = [
+  path.join(process.cwd(), "components"),
+  path.join(process.cwd(), "src", "components"),
+];
+
+const baseComponentsDir =
+  componentLocations.find((dir) => fs.stat(dir).catch(() => false)) ??
+  componentLocations[0];
+
+const TARGET_DIR = path.join(baseComponentsDir, "auth0-ai");
 
 async function syncDir(srcDir, destDir) {
-    try {
-        await fs.access(srcDir); // Ensure source directory exists
-    } catch {
-        throw new Error(`Source directory "${srcDir}" does not exist.`);
-    }
+  try {
+    await fs.access(srcDir); // Ensure source directory exists
+  } catch {
+    throw new Error(`Source directory "${srcDir}" does not exist.`);
+  }
 
-    try {
-        await fs.mkdir(destDir, { recursive: true }); // Ensure destination directory exists
-    } catch (err) {
-        console.error(`Error creating destination directory "${destDir}":`, err);
-        throw err;
-    }
+  try {
+    await fs.mkdir(destDir, { recursive: true }); // Ensure destination directory exists
+  } catch (err) {
+    console.error(`Error creating destination directory "${destDir}":`, err);
+    throw err;
+  }
 
-    const entries = await fs.readdir(srcDir, { withFileTypes: true });
+  const entries = await fs.readdir(srcDir, { withFileTypes: true });
 
-    await Promise.all(entries.map(async (entry) => {
-        const srcPath = path.join(srcDir, entry.name);
-        const destPath = path.join(destDir, entry.name);
+  await Promise.all(
+    entries.map(async (entry) => {
+      const srcPath = path.join(srcDir, entry.name);
+      const destPath = path.join(destDir, entry.name);
 
-        try {
-            await fs.stat(destPath); // Check if file/directory exists
-            console.log(`Skipped file (exists): ${destPath}`);
-        } catch {
-            if (entry.isDirectory()) {
-                await syncDir(srcPath, destPath);
-            } else {
-                await fs.copyFile(srcPath, destPath);
-                console.log(`📄 Copied: ${path.relative(process.cwd(), destPath)}`);
-            }
+      try {
+        await fs.stat(destPath); // Check if file/directory exists
+        console.log(`Skipped file (exists): ${destPath}`);
+      } catch {
+        if (entry.isDirectory()) {
+          await syncDir(srcPath, destPath);
+        } else {
+          await fs.copyFile(srcPath, destPath);
+          console.log(`📄 Copied: ${path.relative(process.cwd(), destPath)}`);
         }
-    }));
+      }
+    })
+  );
 }
 
 async function main() {
-    const args = process.argv.slice(2);
-    if (args.length === 0) {
-        console.log("❌ You must specify a component name. Example: npx @auth0/ai-components add button");
-        process.exit(1);
-    }
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.log(
+      "❌ You must specify a component name. Example: npx @auth0/ai-components add button"
+    );
+    process.exit(1);
+  }
 
-    if (args[0] !== 'add') {
-        console.log("❌ Invalid command. Example: npx @auth0/ai-components add button");
-        process.exit(1);
-    }
+  if (args[0] !== "add") {
+    console.log(
+      "❌ Invalid command. Example: npx @auth0/ai-components add button"
+    );
+    process.exit(1);
+  }
 
-    const components = args.slice(1);
+  const components = args.slice(1);
 
-    const allowedComponents = (await fs.readdir(COMPONENTS_DIR)).filter(f => f !== 'util');
+  const allowedComponents = (await fs.readdir(COMPONENTS_DIR)).filter(
+    (f) => f !== "util"
+  );
 
-    if (!components.every(arg => allowedComponents.includes(arg))) {
-        console.log("❌ Invalid component name. Allowed components:", allowedComponents.join(', '));
-        process.exit(1);
-    }
+  if (!components.every((arg) => allowedComponents.includes(arg))) {
+    console.log(
+      "❌ Invalid component name. Allowed components:",
+      allowedComponents.join(", ")
+    );
+    process.exit(1);
+  }
 
-    console.log(`🚀 Syncing components: ${components.join(', ')}`);
+  console.log(`🚀 Syncing components: ${components.join(", ")}`);
 
+  await syncDir(
+    path.join(COMPONENTS_DIR, "util"),
+    path.join(TARGET_DIR, "util")
+  );
+
+  for (const component of components) {
     await syncDir(
-      path.join(COMPONENTS_DIR, 'util'),
-      path.join(TARGET_DIR, 'util'));
+      path.join(COMPONENTS_DIR, component),
+      path.join(TARGET_DIR, component)
+    );
+  }
 
-    for (const component of components) {
-      await syncDir(
-        path.join(COMPONENTS_DIR, component),
-        path.join(TARGET_DIR, component)
-      );
-    }
+  const { devDependencies } = JSON.parse(
+    await fs.readFile(
+      path.join(import.meta.dirname, "..", "package.json"),
+      "utf-8"
+    )
+  );
+  const recommendedDependencies = Object.keys(devDependencies).filter(
+    (d) => d !== "react" && d !== "typescript" && !d.startsWith("@types/")
+  );
 
-    const { devDependencies } = JSON.parse(await fs.readFile(path.join(import.meta.dirname, '..', 'package.json'), 'utf-8'));
-    const recommendedDependencies = Object.keys(devDependencies).filter(d => d !== 'react' && d !== 'typescript' && !d.startsWith('@types/'));
-
-    console.log('✅ Done!');
-    console.log(`👉 Run \`npm install ${recommendedDependencies.join(' ')}\``);
+  console.log("✅ Done!");
+  console.log(`👉 Run \`npm install ${recommendedDependencies.join(" ")}\``);
 }
 
 main();

--- a/packages/ai-components/templates/FederatedConnections/FederatedConnectionAuthProps.tsx
+++ b/packages/ai-components/templates/FederatedConnections/FederatedConnectionAuthProps.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 /**
  * Defines the mode the EnsureAPIAccess component will use to prompt the user to authorize the API access.

--- a/packages/ai-components/templates/FederatedConnections/index.tsx
+++ b/packages/ai-components/templates/FederatedConnections/index.tsx
@@ -1,6 +1,6 @@
 import { BrowserView, MobileView } from "react-device-detect";
 
-import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
+import type { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 import { EnsureAPIAccessPopup } from "./popup";
 import { EnsureAPIAccessRedirect } from "./redirect";
 

--- a/packages/ai-components/templates/FederatedConnections/popup.tsx
+++ b/packages/ai-components/templates/FederatedConnections/popup.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { WaitingMessage } from "../util/loader";
 import { PromptUserContainer } from "../util/prompt-user-container";
-import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
+import type { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 
 export function EnsureAPIAccessPopup({
   interrupt: { connection, requiredScopes, resume },

--- a/packages/ai-components/templates/FederatedConnections/redirect.tsx
+++ b/packages/ai-components/templates/FederatedConnections/redirect.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PromptUserContainer } from "../util/prompt-user-container";
-import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
+import type { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 
 export function EnsureAPIAccessRedirect({
   interrupt: { requiredScopes, connection },

--- a/packages/ai-components/templates/util/prompt-user-container.tsx
+++ b/packages/ai-components/templates/util/prompt-user-container.tsx
@@ -1,4 +1,4 @@
-import { ClassValue, clsx } from "clsx";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 function cn(...inputs: ClassValue[]) {


### PR DESCRIPTION
This pull request refactors imports across multiple files to explicitly use the `type` keyword for type-only imports, improving code clarity and adhering to best practices. 

It also identifies if the target project uses `./src/components` vs `./components`.

### Refactoring imports for type clarity:
* Updated `FederatedConnectionAuthProps` imports to use the `type` keyword in `FederatedConnectionAuthProps.tsx`, `index.tsx`, `popup.tsx`, and `redirect.tsx`. [[1]](diffhunk://#diff-8c8c398bb48d39b2a04cef38a80cb60a54af27833180afcbf8d2df7bd1c130fcL2-R2) [[2]](diffhunk://#diff-23fe8fb7487fe71205d45207c6dc7894f3d2617276ed1e0bcffbbc5113401117L3-R3) [[3]](diffhunk://#diff-1793e5d5b43409f879dead67e7281c9ab0cfbfc89de660611295c31ee4ee33afL7-R7) [[4]](diffhunk://#diff-7b1fa784a292fa77ead8b1997cae8184405b523fda0d7ab7cb167060b9536a09L4-R4)
* Updated `ClassValue` import in `prompt-user-container.tsx` to use the `type` keyword.