### PR TITLE
feat(ai-compoments): allow authorization path and return to override

### DIFF
--- a/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/FederatedConnectionAuthProps.tsx
+++ b/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/FederatedConnectionAuthProps.tsx
@@ -15,6 +15,10 @@ export type FederatedConnectionAuthProps = {
     requiredScopes: string[];
     resume?: () => void;
   };
+  auth?: {
+    authorizePath?: string;
+    returnTo?: string;
+  };
   onFinish?: () => void;
   connectWidget: {
     icon?: ReactNode;

--- a/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/popup.tsx
+++ b/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/popup.tsx
@@ -9,6 +9,7 @@ import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 export function EnsureAPIAccessPopup({
   interrupt: { connection, requiredScopes, resume },
   connectWidget: { icon, title, description, action, containerClassName },
+  auth: { authorizePath = "/auth/login", returnTo = "/close" } = {},
   onFinish,
 }: FederatedConnectionAuthProps) {
   const [isLoading, setIsLoading] = useState(false);
@@ -41,17 +42,20 @@ export function EnsureAPIAccessPopup({
 
   //Open the login popup
   const startLoginPopup = useCallback(async () => {
-    const params = new URLSearchParams({
+    const search = new URLSearchParams({
+      returnTo,
       connection,
       access_type: "offline",
       prompt: "consent",
       connection_scope: requiredScopes.join(),
-      returnTo: "/close",
     });
-    const url = `/auth/login?${params.toString()}`;
+
+    const url = new URL(authorizePath, window.location.origin);
+    url.search = search.toString();
+
     const windowFeatures =
       "width=800,height=650,status=no,toolbar=no,menubar=no";
-    const popup = window.open(url, "_blank", windowFeatures);
+    const popup = window.open(url.toString(), "_blank", windowFeatures);
     if (!popup) {
       console.error("Popup blocked by the browser");
       return;

--- a/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/redirect.tsx
+++ b/examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/redirect.tsx
@@ -6,6 +6,10 @@ import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 export function EnsureAPIAccessRedirect({
   interrupt: { requiredScopes, connection },
   connectWidget: { icon, title, description, action, containerClassName },
+  auth: {
+    authorizePath = "/auth/login",
+    returnTo = window.location.pathname,
+  } = {},
 }: FederatedConnectionAuthProps) {
   return (
     <PromptUserContainer
@@ -16,14 +20,18 @@ export function EnsureAPIAccessRedirect({
       action={{
         label: action?.label ?? "Connect",
         onClick: () => {
-          const params = new URLSearchParams({
+          const search = new URLSearchParams({
+            returnTo,
             connection,
             access_type: "offline",
             connection_scope: requiredScopes.join(),
-            returnTo: window.location.pathname,
           });
-          const url = `/api/auth/login?${params.toString()}`;
-          window.location.href = url;
+
+          const url = new URL(authorizePath, window.location.origin);
+          url.search = search.toString();
+
+          // Redirect to the authorization page
+          window.location.href = url.toString();
         },
       }}
     />

--- a/packages/ai-components/templates/FederatedConnections/FederatedConnectionAuthProps.tsx
+++ b/packages/ai-components/templates/FederatedConnections/FederatedConnectionAuthProps.tsx
@@ -15,6 +15,10 @@ export type FederatedConnectionAuthProps = {
     requiredScopes: string[];
     resume?: () => void;
   };
+  auth?: {
+    authorizePath?: string;
+    returnTo?: string;
+  };
   onFinish?: () => void;
   connectWidget: {
     icon?: ReactNode;

--- a/packages/ai-components/templates/FederatedConnections/popup.tsx
+++ b/packages/ai-components/templates/FederatedConnections/popup.tsx
@@ -9,6 +9,7 @@ import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 export function EnsureAPIAccessPopup({
   interrupt: { connection, requiredScopes, resume },
   connectWidget: { icon, title, description, action, containerClassName },
+  auth: { authorizePath = "/auth/login", returnTo = "/close" } = {},
   onFinish,
 }: FederatedConnectionAuthProps) {
   const [isLoading, setIsLoading] = useState(false);
@@ -41,17 +42,20 @@ export function EnsureAPIAccessPopup({
 
   //Open the login popup
   const startLoginPopup = useCallback(async () => {
-    const params = new URLSearchParams({
+    const search = new URLSearchParams({
+      returnTo,
       connection,
       access_type: "offline",
       prompt: "consent",
       connection_scope: requiredScopes.join(),
-      returnTo: "/close",
     });
-    const url = `/auth/login?${params.toString()}`;
+
+    const url = new URL(authorizePath, window.location.origin);
+    url.search = search.toString();
+
     const windowFeatures =
       "width=800,height=650,status=no,toolbar=no,menubar=no";
-    const popup = window.open(url, "_blank", windowFeatures);
+    const popup = window.open(url.toString(), "_blank", windowFeatures);
     if (!popup) {
       console.error("Popup blocked by the browser");
       return;

--- a/packages/ai-components/templates/FederatedConnections/redirect.tsx
+++ b/packages/ai-components/templates/FederatedConnections/redirect.tsx
@@ -6,6 +6,10 @@ import { FederatedConnectionAuthProps } from "./FederatedConnectionAuthProps";
 export function EnsureAPIAccessRedirect({
   interrupt: { requiredScopes, connection },
   connectWidget: { icon, title, description, action, containerClassName },
+  auth: {
+    authorizePath = "/auth/login",
+    returnTo = window.location.pathname,
+  } = {},
 }: FederatedConnectionAuthProps) {
   return (
     <PromptUserContainer
@@ -16,14 +20,18 @@ export function EnsureAPIAccessRedirect({
       action={{
         label: action?.label ?? "Connect",
         onClick: () => {
-          const params = new URLSearchParams({
+          const search = new URLSearchParams({
+            returnTo,
             connection,
             access_type: "offline",
             connection_scope: requiredScopes.join(),
-            returnTo: window.location.pathname,
           });
-          const url = `/api/auth/login?${params.toString()}`;
-          window.location.href = url;
+
+          const url = new URL(authorizePath, window.location.origin);
+          url.search = search.toString();
+
+          // Redirect to the authorization page
+          window.location.href = url.toString();
         },
       }}
     />


### PR DESCRIPTION
This pull request introduces enhancements to the `FederatedConnectionAuthProps` type and updates the `EnsureAPIAccessPopup` and `EnsureAPIAccessRedirect` components to support customizable authentication paths and return URLs. These changes improve flexibility in handling authentication flows for federated connections.

### Enhancements to `FederatedConnectionAuthProps`:

* Added an optional `auth` object to the `FederatedConnectionAuthProps` type, allowing customization of `authorizePath` and `returnTo` values. (`examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/FederatedConnectionAuthProps.tsx` [[1]](diffhunk://#diff-4f3834a498cb5214c30eda5b899dae9f2daa2c98de76699e8d4685dabc47963aR18-R21) `packages/ai-components/templates/FederatedConnections/FederatedConnectionAuthProps.tsx` [[2]](diffhunk://#diff-4f3834a498cb5214c30eda5b899dae9f2daa2c98de76699e8d4685dabc47963aR18-R21)

### Updates to `EnsureAPIAccessPopup`:

* Added support for the `auth` property in the `EnsureAPIAccessPopup` component, with default values for `authorizePath` (`/auth/login`) and `returnTo` (`/close`). (`examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/popup.tsx` [[1]](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dR12) `packages/ai-components/templates/FederatedConnections/popup.tsx` [[2]](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dR12)
* Refactored the login popup logic to dynamically construct the URL using `authorizePath` and `returnTo`, replacing hardcoded values. (`examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/popup.tsx` [[1]](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dL44-R58) `packages/ai-components/templates/FederatedConnections/popup.tsx` [[2]](diffhunk://#diff-7e8c9dfcf3cc725b76ff67bf7fc70e7dc1669d4ff8fd7d885503b5d01856c14dL44-R58)

### Updates to `EnsureAPIAccessRedirect`:

* Added support for the `auth` property in the `EnsureAPIAccessRedirect` component, with default values for `authorizePath` (`/auth/login`) and `returnTo` (current `window.location.pathname`). (`examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/redirect.tsx` [[1]](diffhunk://#diff-63a61a5bd2e5d919159130781e62f01d3482e818fe8019448c8f817ab5c7d940R9-R12) `packages/ai-components/templates/FederatedConnections/redirect.tsx` [[2]](diffhunk://#diff-63a61a5bd2e5d919159130781e62f01d3482e818fe8019448c8f817ab5c7d940R9-R12)
* Refactored the redirect logic to dynamically construct the URL using `authorizePath` and `returnTo`, replacing hardcoded values. (`examples/calling-apis/chatbot/components/auth0-ai/FederatedConnections/redirect.tsx` [[1]](diffhunk://#diff-63a61a5bd2e5d919159130781e62f01d3482e818fe8019448c8f817ab5c7d940L19-R34) `packages/ai-components/templates/FederatedConnections/redirect.tsx` [[2]](diffhunk://#diff-63a61a5bd2e5d919159130781e62f01d3482e818fe8019448c8f817ab5c7d940L19-R34)