### PR TITLE
chore(examples): fix calling-apis/chatbot langgraph credential retrieval

### DIFF
--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/list-repositories.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/tools/list-repositories.ts
@@ -12,12 +12,12 @@ export const listRepositories = withGitHub(
   tool(
     async () => {
       // Get the access token from Auth0 AI
-      const accessToken = getCredentialsForConnection();
+      const credentials = getCredentialsForConnection();
 
       // GitHub SDK
       try {
         const octokit = new Octokit({
-          auth: accessToken,
+          auth: credentials?.accessToken,
         });
 
         const { data } = await octokit.rest.repos.listForAuthenticatedUser();


### PR DESCRIPTION
This pull request includes a small update to the `listRepositories` function in the `list-repositories.ts` file. The change involves renaming the `accessToken` variable to `credentials` and updating the `auth` property to use `credentials?.accessToken` instead.

* [`list-repositories.ts`](diffhunk://#diff-cb8e686f76c1a464c97ee262edef62633a8c693576bf8f4292f6655bf3d36b57L15-R20): Renamed `accessToken` to `credentials` and updated the GitHub SDK `auth` property to use `credentials?.accessToken` for improved null safety.