### PR TITLE
feat(ciba): add support for RAR requests for CIBA

### DIFF
--- a/packages/ai-genkit/README.md
+++ b/packages/ai-genkit/README.md
@@ -146,7 +146,7 @@ const buyStockAuthorizer = auth0AI.withAsyncUserConfirmation({
   },
   // The scopes and audience to request
   audience: process.env["AUDIENCE"],
-  scopes: ["stock:trade"]  
+  scopes: ["stock:trade"]
 });
 ```
 
@@ -191,6 +191,37 @@ export const buyTool = ai.defineTool(
   })
 );
 ```
+
+### CIBA with RAR (Rich Authorization Requests)
+Auth0 supports RAR (Rich Authorization Requests) for CIBA. This allows you to provide additional authorization parameters to be displayed during the user confirmation request.
+
+When defining the tool authorizer, you can specify the `authorizationDetails` parameter to include detailed information about the authorization being requested:
+
+```js
+const buyStockAuthorizer = auth0AI.withAsyncUserConfirmation({
+  // A callback to retrieve the userID from tool context.
+  userID: (_params, config) => {
+    return config.configurable?.user_id;
+  },
+  // The message the user will see on the notification
+  bindingMessage: async ({ qty , ticker }) => {
+    return `Confirm the purchase of ${qty} ${ticker}`;
+  },
+  authorizationDetails: async ({ qty, ticker }) => {
+    return [{ type: "trade_authorization", qty, ticker, action: "buy" }];
+  },
+  // The scopes and audience to request
+  audience: process.env["AUDIENCE"],
+  scopes: ["stock:trade"]
+});
+```
+
+To use RAR with CIBA, you need to [set up authorization details](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests) in your Auth0 tenant. This includes defining the authorization request parameters and their types. Additionally, the [Guardian SDK](https://auth0.com/docs/secure/multi-factor-authentication/auth0-guardian) is required to handle these authorization details in your authorizer app.
+
+For more information on setting up RAR with CIBA, refer to:
+- [Configure Rich Authorization Requests (RAR)](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests)
+- [User Authorization with CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba)
+
 
 ## Device Flow Authorizer
 

--- a/packages/ai-langchain/README.md
+++ b/packages/ai-langchain/README.md
@@ -173,7 +173,7 @@ const buyStockAuthorizer = auth0AI.withAsyncUserConfirmation({
   },
   // The scopes and audience to request
   audience: process.env["AUDIENCE"],
-  scopes: ["stock:trade"]  
+  scopes: ["stock:trade"]
 });
 ```
 
@@ -217,6 +217,36 @@ export const buyTool = buyStockAuthorizer(
   })
 );
 ```
+
+### CIBA with RAR (Rich Authorization Requests)
+Auth0 supports RAR (Rich Authorization Requests) for CIBA. This allows you to provide additional authorization parameters to be displayed during the user confirmation request.
+
+When defining the tool authorizer, you can specify the `authorizationDetails` parameter to include detailed information about the authorization being requested:
+
+```js
+const buyStockAuthorizer = auth0AI.withAsyncUserConfirmation({
+  // A callback to retrieve the userID from tool context.
+  userID: (_params, config) => {
+    return config.configurable?.user_id;
+  },
+  // The message the user will see on the notification
+  bindingMessage: async ({ qty , ticker }) => {
+    return `Confirm the purchase of ${qty} ${ticker}`;
+  },
+  authorizationDetails: async ({ qty, ticker }) => {
+    return [{ type: "trade_authorization", qty, ticker, action: "buy" }];
+  },
+  // The scopes and audience to request
+  audience: process.env["AUDIENCE"],
+  scopes: ["stock:trade"]
+});
+```
+
+To use RAR with CIBA, you need to [set up authorization details](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests) in your Auth0 tenant. This includes defining the authorization request parameters and their types. Additionally, the [Guardian SDK](https://auth0.com/docs/secure/multi-factor-authentication/auth0-guardian) is required to handle these authorization details in your authorizer app.
+
+For more information on setting up RAR with CIBA, refer to:
+- [Configure Rich Authorization Requests (RAR)](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests)
+- [User Authorization with CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba)
 
 ## Device Flow Authorizer
 
@@ -368,7 +398,7 @@ It is important that you disable error handling in your tools node as follows:
   .addNode(
     "tools",
     new ToolNode(
-      [ 
+      [
         // your authorizer-wrapped tools
       ],
       {
@@ -395,7 +425,7 @@ const interrupts = getAuth0Interrupts(thread.interrupts);
 // Handle an specific interrupt:
 if(interrupts[0] &&
   AuthorizationPendingInterrupt.isInterrupt(interrupts[0].value)) {
-  
+
 }
 ```
 
@@ -407,9 +437,9 @@ client.runs.wait(thread.id, t.assistantID, {})
 
 Since Auth0AI has persistence on the backend you typically don't need to reattach interrupt's information when resuming.
 
-For the specific case of **Client-Initiated Backchannel Authorization** you might attach a `GraphResumer` instance which watch for interrupted threads in the state of `Authorization Pending` and try to resume them automatically respecting Auth0's polling interval. 
+For the specific case of **Client-Initiated Backchannel Authorization** you might attach a `GraphResumer` instance which watch for interrupted threads in the state of `Authorization Pending` and try to resume them automatically respecting Auth0's polling interval.
 
-```js 
+```js
 import { GraphResumer } from "@auth0/ai-langchain";
 import { Client } from "@langchain/langgraph-sdk";
 

--- a/packages/ai-llamaindex/README.md
+++ b/packages/ai-llamaindex/README.md
@@ -146,7 +146,7 @@ export const buyStockAuthorizer = auth0AI.withAsyncUserConfirmation({
   },
   // The scopes and audience to request
   audience: process.env["AUDIENCE"],
-  scopes: ["stock:trade"]  
+  scopes: ["stock:trade"]
 });
 ```
 
@@ -190,6 +190,35 @@ export const purchaseStock = buyStockAuthorizer(
   })
 );
 ```
+
+### CIBA with RAR (Rich Authorization Requests)
+Auth0 supports RAR (Rich Authorization Requests) for CIBA. This allows you to provide additional authorization parameters to be displayed during the user confirmation request.
+
+When defining the tool authorizer, you can specify the `authorizationDetails` parameter to include detailed information about the authorization being requested:
+
+```js
+const buyStockAuthorizer = auth0AI.withAsyncUserConfirmation({
+  // A callback to retrieve the userID from tool context.
+  userID: (params: { userID: string }, ctx) => params.userID,
+
+  // The message the user will see on the notification
+  bindingMessage: async ({ qty , ticker }) => {
+    return `Confirm the purchase of ${qty} ${ticker}`;
+  },
+  authorizationDetails: async ({ qty, ticker }) => {
+    return [{ type: "trade_authorization", qty, ticker, action: "buy" }];
+  },
+  // The scopes and audience to request
+  audience: process.env["AUDIENCE"],
+  scopes: ["stock:trade"]
+});
+```
+
+To use RAR with CIBA, you need to [set up authorization details](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests) in your Auth0 tenant. This includes defining the authorization request parameters and their types. Additionally, the [Guardian SDK](https://auth0.com/docs/secure/multi-factor-authentication/auth0-guardian) is required to handle these authorization details in your authorizer app.
+
+For more information on setting up RAR with CIBA, refer to:
+- [Configure Rich Authorization Requests (RAR)](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests)
+- [User Authorization with CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba)
 
 ## Device Flow Authorizer
 

--- a/packages/ai-vercel/README.md
+++ b/packages/ai-vercel/README.md
@@ -184,6 +184,35 @@ export const purchaseStock = buyStockAuthorizer({
 });
 ```
 
+### CIBA with RAR (Rich Authorization Requests)
+Auth0 supports RAR (Rich Authorization Requests) for CIBA. This allows you to provide additional authorization parameters to be displayed during the user confirmation request.
+
+When defining the tool authorizer, you can specify the `authorizationDetails` parameter to include detailed information about the authorization being requested:
+
+```js
+const buyStockAuthorizer = auth0AI.withAsyncUserConfirmation({
+  // A callback to retrieve the userID from tool context.
+  userID: (params: { userID: string }, ctx) => params.userID,
+
+  // The message the user will see on the notification
+  bindingMessage: async ({ qty , ticker }) => {
+    return `Confirm the purchase of ${qty} ${ticker}`;
+  },
+  authorizationDetails: async ({ qty, ticker }) => {
+    return [{ type: "trade_authorization", qty, ticker, action: "buy" }];
+  },
+  // The scopes and audience to request
+  audience: process.env["AUDIENCE"],
+  scopes: ["stock:trade"]
+});
+```
+
+To use RAR with CIBA, you need to [set up authorization details](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests) in your Auth0 tenant. This includes defining the authorization request parameters and their types. Additionally, the [Guardian SDK](https://auth0.com/docs/secure/multi-factor-authentication/auth0-guardian) is required to handle these authorization details in your authorizer app.
+
+For more information on setting up RAR with CIBA, refer to:
+- [Configure Rich Authorization Requests (RAR)](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests)
+- [User Authorization with CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba)
+
 ## Device Flow Authorizer
 
 The Device Flow Authorizer enables secure, user-in-the-loop authentication for devices or tools that cannot directly authenticate users. It uses the OAuth 2.0 Device Authorization Grant to request user authorization and resume execution once authorization is granted.

--- a/packages/ai/src/authorizers/ciba/CIBAAuthorizerParams.ts
+++ b/packages/ai/src/authorizers/ciba/CIBAAuthorizerParams.ts
@@ -8,6 +8,11 @@ import { CIBAAuthorizationRequest } from "./CIBAAuthorizationRequest";
 
 export type CIBAAuthorizerParams<ToolExecuteArgs extends any[]> = {
   /**
+   * The scope to request authorization for.
+   */
+  scopes: string[];
+
+  /**
    * The user ID to request authorization for.
    */
   userID: AuthorizerToolParameter<ToolExecuteArgs>;
@@ -18,9 +23,12 @@ export type CIBAAuthorizerParams<ToolExecuteArgs extends any[]> = {
   bindingMessage: AuthorizerToolParameter<ToolExecuteArgs>;
 
   /**
-   * The scope to request authorization for.
+   * The authorization parameters for RAR request.
    */
-  scopes: string[];
+  authorizationDetails?: AuthorizerToolParameter<
+    ToolExecuteArgs,
+    Record<string, any>[]
+  >;
 
   /**
    * The audience to request authorization for.


### PR DESCRIPTION
This pull request introduces support for Rich Authorization Requests (RAR) in Client-Initiated Backchannel Authentication (CIBA) across multiple packages and updates the CIBA authorizer implementation to handle RAR parameters. The changes include updates to documentation, new parameters for the CIBA authorizer, and enhancements to the internal authorization logic.

### Documentation Updates:
* Added detailed sections on using RAR with CIBA in the `README.md` files for `ai-genkit`, `ai-langchain`, `ai-llamaindex`, and `ai-vercel`. These sections include code examples, setup instructions, and links to relevant Auth0 documentation. [[1]](diffhunk://#diff-f9006b9deabd93286a1ba9ef95c56e9c4c2e9cf0d86c0e62f092f91b66509cc5R195-R225) [[2]](diffhunk://#diff-8fb1cf4cde044d4166b3bda4d69c651c166999d1c6eb19a8b25446dde5036628R221-R250) [[3]](diffhunk://#diff-f1d5e05ebabe99ff7782e0fb6d7a70909d41276dc69bc612a2027706d237b64bR194-R222) [[4]](diffhunk://#diff-6c7b20f5b315d5227899a28d3b17d1fd20266b33e2bb028eb4be0708458a79aeR187-R215)

### Enhancements to CIBA Authorizer:
* Updated the `CIBAAuthorizerBase` class to include support for the `authorizationDetails` parameter. This parameter is resolved and serialized into a JSON string to comply with Auth0's requirements. Undefined values are also filtered out from the final authorization parameters.
* Modified the `CIBAAuthorizerParams` type to add the optional `authorizationDetails` parameter for RAR support and updated the `scopes` parameter documentation. [[1]](diffhunk://#diff-c37e6b63b195215d9a26f2897211c2fbd1273c480ecdd967f9b83018e58e9dfeR10-R14) [[2]](diffhunk://#diff-c37e6b63b195215d9a26f2897211c2fbd1273c480ecdd967f9b83018e58e9dfeL21-R31)