### PR TITLE
feat: add auth0 client telemetry config

### DIFF
--- a/packages/ai/src/authorizers/types.ts
+++ b/packages/ai/src/authorizers/types.ts
@@ -18,6 +18,13 @@ export const Auth0ClientSchema = z.object({
   domain: z.string().default(() => process.env.AUTH0_DOMAIN!),
   clientId: z.string().default(() => process.env.AUTH0_CLIENT_ID!),
   clientSecret: z.string().default(() => process.env.AUTH0_CLIENT_SECRET!),
+  telemetry: z.boolean().optional(),
+  clientInfo: z
+    .object({
+      name: z.string(),
+    })
+    .passthrough()
+    .optional(),
 });
 
 export const Auth0PublicClientSchema = z.object({


### PR DESCRIPTION
This pull request introduces enhancements to the `Auth0ClientSchema` in `packages/ai/src/authorizers/types.ts` by adding support for optional telemetry and client information fields.

Enhancements to `Auth0ClientSchema`:

* Added a new optional `telemetry` field of type `boolean` to allow configuration of telemetry settings.
* Introduced an optional `clientInfo` field, which is an object containing a `name` property of type `string`, with support for additional properties via `.passthrough()`.