### PR TITLE
fix: configuration types for auth0

### DIFF
--- a/packages/ai-genkit/src/Auth0AI.ts
+++ b/packages/ai-genkit/src/Auth0AI.ts
@@ -11,7 +11,7 @@ import { FGA_AI } from "./FGA_AI";
 
 import type { ToolWrapper, ToolDefinition } from "./lib";
 
-type AuthorizerParams = Pick<
+type Auth0ClientParams = Pick<
   AuthenticationClientOptions,
   "domain" | "clientId" | "clientSecret"
 >;
@@ -32,13 +32,13 @@ export type FederatedConnectionParams = Omit<
 >;
 
 type Auth0AIParams = {
-  auth0?: Partial<AuthorizerParams>;
+  auth0?: Partial<Auth0ClientParams>;
   store?: Store;
   genkit: GenkitBeta;
 };
 
 export class Auth0AI {
-  private config: Partial<AuthorizerParams>;
+  private config: Partial<Auth0ClientParams>;
   private store: SubStore;
   private genkit: GenkitBeta;
 

--- a/packages/ai-langchain/src/Auth0AI.ts
+++ b/packages/ai-langchain/src/Auth0AI.ts
@@ -1,4 +1,4 @@
-import { AuthorizerParams } from "@auth0/ai";
+import { Auth0ClientParams } from "@auth0/ai";
 import { MemoryStore, Store, SubStore } from "@auth0/ai/stores";
 
 import { CIBAAuthorizer } from "./ciba";
@@ -23,12 +23,12 @@ export type DeviceParams = Omit<
 >;
 
 type Auth0AIParams = {
-  auth0?: Partial<AuthorizerParams>;
+  auth0?: Partial<Auth0ClientParams>;
   store?: Store;
 };
 
 export class Auth0AI {
-  private config: Partial<AuthorizerParams>;
+  private config: Partial<Auth0ClientParams>;
   private store: SubStore;
 
   constructor({ auth0, store }: Auth0AIParams = {}) {

--- a/packages/ai-llamaindex/src/Auth0AI.ts
+++ b/packages/ai-llamaindex/src/Auth0AI.ts
@@ -7,7 +7,7 @@ import { DeviceAuthorizer } from "./Device";
 import { FederatedConnectionAuthorizer } from "./FederatedConnections";
 import { FGA_AI } from "./FGA_AI";
 
-import type { AuthorizerParams } from "@auth0/ai";
+import type { Auth0ClientParams } from "@auth0/ai";
 type ToolWrapper = ReturnType<FederatedConnectionAuthorizer["authorizer"]>;
 type FederatedConnectionParams = Omit<
   ConstructorParameters<typeof FederatedConnectionAuthorizer>[1],
@@ -25,12 +25,12 @@ export type DeviceParams = Omit<
 >;
 
 type Auth0AIParams = {
-  auth0?: Partial<AuthorizerParams>;
+  auth0?: Partial<Auth0ClientParams>;
   store?: Store;
 };
 
 export class Auth0AI {
-  private config: Partial<AuthorizerParams>;
+  private config: Partial<Auth0ClientParams>;
   private store: SubStore;
 
   constructor({ auth0, store }: Auth0AIParams = {}) {

--- a/packages/ai-vercel/src/Auth0AI.ts
+++ b/packages/ai-vercel/src/Auth0AI.ts
@@ -8,7 +8,7 @@ import { FederatedConnectionAuthorizer } from "./FederatedConnections";
 import { FGA_AI } from "./FGA_AI";
 import { ToolWrapper } from "./util/ToolWrapper";
 
-import type { AuthorizerParams } from "@auth0/ai";
+import type { Auth0ClientParams } from "@auth0/ai";
 
 type FederatedConnectionParams = Omit<
   ConstructorParameters<typeof FederatedConnectionAuthorizer>[1],
@@ -26,12 +26,12 @@ export type DeviceParams = Omit<
 >;
 
 type Auth0AIParams = {
-  auth0?: Partial<AuthorizerParams>;
+  auth0?: Partial<Auth0ClientParams>;
   store?: Store;
 };
 
 export class Auth0AI {
-  private config: Partial<AuthorizerParams>;
+  private config: Partial<Auth0ClientParams>;
   private store: SubStore;
 
   constructor({ auth0, store }: Auth0AIParams = {}) {

--- a/packages/ai/src/authorizers/types.ts
+++ b/packages/ai/src/authorizers/types.ts
@@ -1,4 +1,3 @@
-import { AuthenticationClientOptions } from "auth0";
 import * as jose from "jose";
 import { z } from "zod";
 
@@ -17,7 +16,9 @@ export type ToolWithAuthHandler<I, O, C> = (
 export const Auth0ClientSchema = z.object({
   domain: z.string().default(() => process.env.AUTH0_DOMAIN!),
   clientId: z.string().default(() => process.env.AUTH0_CLIENT_ID!),
-  clientSecret: z.string().default(() => process.env.AUTH0_CLIENT_SECRET!),
+  clientSecret: z
+    .union([z.string(), z.undefined()])
+    .transform((v) => v ?? process.env.AUTH0_CLIENT_SECRET),
   telemetry: z.boolean().optional(),
   clientInfo: z
     .object({
@@ -34,10 +35,5 @@ export const Auth0PublicClientSchema = z.object({
 
 export type Auth0ClientParams = z.infer<typeof Auth0ClientSchema>;
 export type Auth0PublicClientParams = z.infer<typeof Auth0PublicClientSchema>;
-
-export type AuthorizerParams = Pick<
-  AuthenticationClientOptions,
-  "domain" | "clientId" | "clientSecret"
->;
 
 export type OnAuthorizationRequest = "block" | "interrupt";

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,4 +1,4 @@
-export type { AuthParams, AuthorizerParams } from "./authorizers/types";
+export type { AuthParams, Auth0ClientParams } from "./authorizers/types";
 export type * from "./credentials";
 export * from "./errors";
 export * from "./authorizers/fga/fga-filter";


### PR DESCRIPTION
This pull request refactors the `AuthorizerParams` type across multiple packages to improve consistency and flexibility by replacing it with `Auth0ClientParams`. Additionally, it updates the `Auth0ClientSchema` to handle optional `clientSecret` values more gracefully. Below are the most important changes grouped by theme:

### Type Refactoring
* Replaced the `AuthorizerParams` type with `Auth0ClientParams` in `Auth0AI.ts` files across the `ai-genkit`, `ai-langchain`, `ai-llamaindex`, and `ai-vercel` packages. This change impacts type definitions for `Auth0AIParams` and the `config` property of the `Auth0AI` class. [[1]](diffhunk://#diff-d689a7f4b8e1648e36cee9b47b2420e4c0d58987d7b54afdc6bd9ffe03a48447L14-R14) [[2]](diffhunk://#diff-d689a7f4b8e1648e36cee9b47b2420e4c0d58987d7b54afdc6bd9ffe03a48447L35-R41) [[3]](diffhunk://#diff-85272b167a0f51b0605c4296ac671562556340ad226f1fea048cb1aafd39b5b0L1-R1) [[4]](diffhunk://#diff-85272b167a0f51b0605c4296ac671562556340ad226f1fea048cb1aafd39b5b0L26-R31) [[5]](diffhunk://#diff-f44317e8f2d86833fe340e862c78e6776ed987b85cf8eaada329d5ba04074ef2L10-R10) [[6]](diffhunk://#diff-f44317e8f2d86833fe340e862c78e6776ed987b85cf8eaada329d5ba04074ef2L28-R33) [[7]](diffhunk://#diff-d5d9b6e61e338fbeeb2ca081e2eb349d8d1c0b5aec7565b4c44344e65dcea8a0L11-R11) [[8]](diffhunk://#diff-d5d9b6e61e338fbeeb2ca081e2eb349d8d1c0b5aec7565b4c44344e65dcea8a0L29-R34)

### Schema Updates
* Updated `Auth0ClientSchema` in `packages/ai/src/authorizers/types.ts` to allow `clientSecret` to be either a string or undefined. If undefined, it defaults to the `AUTH0_CLIENT_SECRET` environment variable.

### Cleanup and Export Adjustments
* Removed the `AuthorizerParams` type from `packages/ai/src/authorizers/types.ts` and replaced its export with `Auth0ClientParams` in `packages/ai/src/index.ts`. [[1]](diffhunk://#diff-cbaea311c873d830d0b7099e633a03687e2c9a9f5620eae52238f7f89b41de40L38-L42) [[2]](diffhunk://#diff-f0fa1410e0d7c9e14beb4ee4a3414a86dc8402e8a89c53a78c7620f2c9b0caacL1-R1)