### PR TITLE
feat: add onAuthorizationInterrupt optional callback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17412,7 +17412,7 @@
         "vitest": "^3.0.9"
       },
       "peerDependencies": {
-        "agents": "0.0.90"
+        "agents": ">=0.0.51 <0.0.91"
       }
     },
     "packages/ai-components": {

--- a/packages/ai-genkit/src/CIBA/CIBAAuthorizer.ts
+++ b/packages/ai-genkit/src/CIBA/CIBAAuthorizer.ts
@@ -25,7 +25,7 @@ export class CIBAAuthorizer extends CIBAAuthorizerBase<
     super(...args);
   }
 
-  protected handleAuthorizationInterrupts(
+  protected async handleAuthorizationInterrupts(
     err: AuthorizationPendingInterrupt | AuthorizationPollingInterrupt
   ) {
     throw toGenKitInterrupt(err);

--- a/packages/ai-langchain/src/ciba/CIBAAuthorizer.ts
+++ b/packages/ai-langchain/src/ciba/CIBAAuthorizer.ts
@@ -13,9 +13,9 @@ import { ToolLike, ToolWrapper } from "../util/ToolWrapper";
  * Authorizer for federated connections.
  */
 export class CIBAAuthorizer extends CIBAAuthorizerBase<[any, any]> {
-  protected override handleAuthorizationInterrupts(
+  protected override async handleAuthorizationInterrupts(
     err: AuthorizationPendingInterrupt | AuthorizationPollingInterrupt
-  ): void {
+  ) {
     throw toGraphInterrupt(err);
   }
 

--- a/packages/ai/src/authorizers/ciba/CIBAAuthorizerBase.ts
+++ b/packages/ai/src/authorizers/ciba/CIBAAuthorizerBase.ts
@@ -319,9 +319,17 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
     };
   }
 
-  protected handleAuthorizationInterrupts(
+  protected async handleAuthorizationInterrupts(
     err: AuthorizationPendingInterrupt | AuthorizationPollingInterrupt
   ) {
+    if (this.params.onAuthorizationInterrupt) {
+      const store = asyncLocalStorage.getStore();
+      if (!store) {
+        throw new Error("This method should be called from within a tool.");
+      }
+      const { context } = store;
+      await this.params.onAuthorizationInterrupt(err, context);
+    }
     throw err;
   }
 }

--- a/packages/ai/src/authorizers/ciba/CIBAAuthorizerParams.ts
+++ b/packages/ai/src/authorizers/ciba/CIBAAuthorizerParams.ts
@@ -1,8 +1,12 @@
 import { TokenSet } from "../../credentials";
-import { CIBAInterrupt } from "../../interrupts";
+import {
+  AuthorizationPendingInterrupt,
+  AuthorizationPollingInterrupt,
+  CIBAInterrupt,
+} from "../../interrupts";
 import { AuthorizerToolParameter } from "../../parameters";
 import { Store } from "../../stores";
-import { AuthContext } from "../context";
+import { AuthContext, ToolCallContext } from "../context";
 import { OnAuthorizationRequest } from "../types";
 import { CIBAAuthorizationRequest } from "./CIBAAuthorizationRequest";
 
@@ -83,6 +87,18 @@ export type CIBAAuthorizerParams<ToolExecuteArgs extends any[]> = {
     err: Error | CIBAInterrupt,
     ...args: ToolExecuteArgs
   ) => any;
+
+  /**
+   * Callback called before the authorization interrupt is thrown.
+   * This callback is useful to setup CIBA pollers.
+   *
+   * @param interrupt - The interrupt that is about to be thrown.
+   * @param args - The tool execution arguments.
+   */
+  onAuthorizationInterrupt?: (
+    interrupt: AuthorizationPendingInterrupt | AuthorizationPollingInterrupt,
+    context: ToolCallContext
+  ) => void | Promise<void>;
 
   /**
    * An store used to temporarly store the authorization response data


### PR DESCRIPTION
This pull request introduces enhancements to the `CIBAAuthorizer` classes across multiple packages, focusing on improving the handling of authorization interrupts. The changes include making the `handleAuthorizationInterrupts` method asynchronous, adding a callback for pre-interrupt handling, and updating tests to validate the new functionality.

### Enhancements to Authorization Interrupt Handling:

* **Asynchronous `handleAuthorizationInterrupts` method**:
  - Updated the `handleAuthorizationInterrupts` method in `CIBAAuthorizer`, `CIBAAuthorizerBase`, and related classes to be asynchronous, enabling better support for asynchronous operations during interrupt handling. (`[[1]](diffhunk://#diff-aaf1f40ddb28ffa98f2ba6ddc1c10c1935501926c15ab7271b2656b48f4c71e8L28-R28)`, `[[2]](diffhunk://#diff-084b6d97ad16a5aa243637199ee67e893fba0aeb8938c30406e42275dec8b5e1L16-R18)`, `[[3]](diffhunk://#diff-2cf9fff819ccab13dd277bfa2895ced65bd203395a1ab65ad513e8298181a6e8L322-R332)`)

* **New `onAuthorizationInterrupt` callback**:
  - Added an optional `onAuthorizationInterrupt` parameter in `CIBAAuthorizerParams`, allowing developers to specify a callback that is invoked before an authorization interrupt is thrown. This provides a mechanism to set up CIBA pollers or perform other pre-interrupt actions. (`[packages/ai/src/authorizers/ciba/CIBAAuthorizerParams.tsR91-R102](diffhunk://#diff-c37e6b63b195215d9a26f2897211c2fbd1273c480ecdd967f9b83018e58e9dfeR91-R102)`)

### Codebase Updates:

* **Refactored imports**:
  - Modified imports in `CIBAAuthorizerParams` to include `AuthorizationPendingInterrupt` and `AuthorizationPollingInterrupt`, ensuring proper type definitions for the new callback functionality. (`[packages/ai/src/authorizers/ciba/CIBAAuthorizerParams.tsL2-R9](diffhunk://#diff-c37e6b63b195215d9a26f2897211c2fbd1273c480ecdd967f9b83018e58e9dfeL2-R9)`)

### Testing Enhancements:

* **Tests for `onAuthorizationInterrupt`**:
  - Added unit tests in `ciba-authorizer.test.ts` to verify that the `onAuthorizationInterrupt` callback is invoked correctly with the expected interrupt and context, and that the interrupt is still thrown after the callback execution. (`[packages/ai/test/ciba/ciba-authorizer.test.tsR517-R578](diffhunk://#diff-21fad5a0974aa265a7e4507b6474f374bc8bda17fb9d2f6a3a3000fea82d0b22R517-R578)`)