### PR TITLE
fix: add missing export setGlobalAIContext

### DIFF
--- a/packages/ai-vercel/src/index.ts
+++ b/packages/ai-vercel/src/index.ts
@@ -7,4 +7,9 @@ export {
   getAccessTokenForConnection,
 } from "./FederatedConnections";
 
-export { setAIContext, runInAIContext, runWithAIContext } from "./context";
+export {
+  setAIContext,
+  runInAIContext,
+  runWithAIContext,
+  setGlobalAIContext,
+} from "./context";


### PR DESCRIPTION
This pull request extends the exported functions from the `context` module in the `packages/ai-vercel/src/index.ts` file. The change adds `setGlobalAIContext` to the list of exported functions, enabling broader context management capabilities.