### PR TITLE
fix: cloudflare store issue with put

### DIFF
--- a/packages/ai-cloudflare/src/CloudflareKVStore.ts
+++ b/packages/ai-cloudflare/src/CloudflareKVStore.ts
@@ -63,10 +63,10 @@ export class CloudflareKVStore<T = any> implements Store<T> {
     if (options?.expiresIn) {
       const expiration =
         Math.floor(Date.now() / 1000) + options.expiresIn / 1000;
-      return this.kv.put(fullKey, value, {
+      return this.kv.put(fullKey, JSON.stringify(value), {
         expiration,
       });
     }
-    return this.kv.put(fullKey, value);
+    return this.kv.put(fullKey, JSON.stringify(value));
   }
 }


### PR DESCRIPTION
This pull request modifies the `CloudflareKVStore` class in `packages/ai-cloudflare/src/CloudflareKVStore.ts` to ensure that all values stored in the KV store are serialized as JSON. This change improves consistency and compatibility when storing and retrieving data.

Key change:

* Updated the `put` method to serialize `value` using `JSON.stringify` before storing it in the KV store, both with and without an expiration option.