### PR TITLE
fix: remove unnecesary setaicontext and fix polling interval

### DIFF
--- a/packages/ai-cloudflare/src/AsyncUserConfirmationResumer.ts
+++ b/packages/ai-cloudflare/src/AsyncUserConfirmationResumer.ts
@@ -1,7 +1,6 @@
 import { Schedule } from "agents";
 import { Message } from "ai";
 
-import { runInAIContext } from "@auth0/ai-vercel";
 import {
   AuthorizationPendingInterrupt,
   AuthorizationPollingInterrupt,
@@ -61,15 +60,15 @@ export const AsyncUserConfirmationResumer = <
      * Schedules an asynchronous user confirmation check.
      *
      * @param params - The parameters for the scheduled task, including the interrupt and context.
-     * @param delayInSeconds - The delay in seconds before the check is executed (default is 5 seconds).
+     * @param delayInSeconds - The delay in seconds before the check is executed (default to Auth request polling interval).
      * @returns A promise that resolves to a Schedule object for the scheduled task.
      */
     async scheduleAsyncUserConfirmationCheck(
       params: ScheduledParamsType,
-      delayInSeconds: number = 5
+      delayInSeconds?: number
     ): Promise<Schedule<ScheduledParamsType>> {
       return this.schedule(
-        delayInSeconds,
+        delayInSeconds ?? params.interrupt.request.interval ?? 60,
         "asyncUserConfirmationCheck",
         params
       );
@@ -116,9 +115,7 @@ export const AsyncUserConfirmationResumer = <
         index === this.messages.indexOf(message) ? newMessage : m
       );
 
-      await runInAIContext({ threadID: this.name }, () =>
-        this.saveMessages(newMessages)
-      );
+      await this.saveMessages(newMessages);
     }
   };
 };

--- a/packages/ai/src/authorizers/ciba/CIBAAuthorizationRequest.ts
+++ b/packages/ai/src/authorizers/ciba/CIBAAuthorizationRequest.ts
@@ -16,7 +16,7 @@ export type CIBAAuthorizationRequest = {
   expiresIn: number;
 
   /**
-   * The interval to use when polling the status.
+   * The interval in seconds to use when polling the status.
    */
   interval: number;
 };


### PR DESCRIPTION
This pull request includes updates to improve the handling of asynchronous user confirmation checks and refines documentation for polling intervals. The most important changes involve modifying default delay logic, removing unnecessary context execution, and clarifying comments for better readability.

### Improvements to asynchronous user confirmation handling:

* [`packages/ai-cloudflare/src/AsyncUserConfirmationResumer.ts`](diffhunk://#diff-35912d4f7bec16d48d3b6116e87f84ca6f6bba36062c4cdbcc9dac91d6273cfaL64-R71): Updated the `scheduleAsyncUserConfirmationCheck` method to use a dynamic default delay based on the `interrupt.request.interval` or fallback to 60 seconds if not provided. This enhances flexibility in scheduling tasks.
* [`packages/ai-cloudflare/src/AsyncUserConfirmationResumer.ts`](diffhunk://#diff-35912d4f7bec16d48d3b6116e87f84ca6f6bba36062c4cdbcc9dac91d6273cfaL119-R118): Removed the `runInAIContext` call and directly invoked `saveMessages`, simplifying the code and reducing dependency on external context execution.

### Documentation improvements:

* [`packages/ai/src/authorizers/ciba/CIBAAuthorizationRequest.ts`](diffhunk://#diff-6240556c3a8c1a63d30ca414347951d58563e726cd7969ddf38bd82fb637b377L19-R19): Updated the comment for the `interval` property to specify that the interval is in seconds, improving clarity for developers.