### PR TITLE
fix: update llamaindex dep to ^0.11.28

### DIFF
--- a/examples/async-user-confirmation/llamaindex/package.json
+++ b/examples/async-user-confirmation/llamaindex/package.json
@@ -16,10 +16,11 @@
   "dependencies": {
     "@auth0/ai": "*",
     "@auth0/ai-llamaindex": "*",
+    "@llamaindex/openai": "^0.4.18",
     "dotenv": "^16.4.7",
     "enquirer": "^2.4.1",
     "jwt-decode": "^4.0.0",
-    "llamaindex": "^0.9.0",
+    "llamaindex": "^0.11.28",
     "open": "^10.1.0",
     "zod": "^3.24.1"
   }

--- a/examples/async-user-confirmation/llamaindex/src/index.ts
+++ b/examples/async-user-confirmation/llamaindex/src/index.ts
@@ -1,19 +1,25 @@
 import "dotenv/config";
 
 import Enquirer from "enquirer";
-import { OpenAIAgent } from "llamaindex";
+import { ReActAgent, Settings } from "llamaindex";
+import { openai } from "@llamaindex/openai";
 import { randomUUID } from "node:crypto";
 
 import { setAIContext } from "@auth0/ai-llamaindex";
 
 import { buyTool } from "./tools/buy";
 
+// Configure OpenAI LLM
+Settings.llm = openai({
+  model: "gpt-4o-mini",
+});
+
 async function main() {
   console.log(`<Enter a command (type "exit" to quit)>\n\n`);
   const enquirer = new Enquirer<{ message: string }>();
   setAIContext({ threadID: randomUUID() });
 
-  const agent = new OpenAIAgent({
+  const agent = new ReActAgent({
     tools: [buyTool()],
     verbose: true,
   });

--- a/examples/authorization-for-rag/llamaindex/package.json
+++ b/examples/authorization-for-rag/llamaindex/package.json
@@ -18,6 +18,6 @@
     "@auth0/ai-llamaindex": "*",
     "@openfga/sdk": "^0.8.0",
     "dotenv": "^16.5.0",
-    "llamaindex": "^0.9.0"
+    "llamaindex": "^0.11.28"
   }
 }

--- a/examples/authorization-for-tools/llamaindex/package.json
+++ b/examples/authorization-for-tools/llamaindex/package.json
@@ -15,11 +15,12 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@auth0/ai-llamaindex": "*",
+    "@llamaindex/openai": "^0.4.18",
     "@openfga/sdk": "^0.8.0",
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.7",
     "enquirer": "^2.4.1",
-    "llamaindex": "^0.9.0",
+    "llamaindex": "^0.11.28",
     "zod": "^3.24.1"
   }
 }

--- a/examples/authorization-for-tools/llamaindex/src/index.ts
+++ b/examples/authorization-for-tools/llamaindex/src/index.ts
@@ -1,16 +1,22 @@
 import "dotenv/config";
 
 import Enquirer from "enquirer";
-import { OpenAIAgent } from "llamaindex";
+import { Settings, ReActAgent } from "llamaindex";
+import { openai } from "@llamaindex/openai";
 
 import { systemPrompt } from "./system";
 import { buyTool } from "./tools/buy";
+
+// Configure OpenAI LLM
+Settings.llm = openai({
+  model: "gpt-4o-mini",
+});
 
 async function main() {
   console.log(`<Enter a command (type "exit" to quit)>\n\n`);
   const enquirer = new Enquirer<{ message: string }>();
 
-  const agent = new OpenAIAgent({
+  const agent = new ReActAgent({
     systemPrompt: systemPrompt,
     tools: [
       buyTool({

--- a/examples/calling-apis/chatbot/app/(llamaindex)/api/llamaindex/route.ts
+++ b/examples/calling-apis/chatbot/app/(llamaindex)/api/llamaindex/route.ts
@@ -4,7 +4,8 @@ import {
   Message,
   ToolExecutionError,
 } from "ai";
-import { ChatMessage, OpenAIAgent } from "llamaindex";
+import { ReActAgent, Settings } from "llamaindex";
+import { openai } from "@llamaindex/openai";
 
 import {
   checkUsersCalendar,
@@ -15,6 +16,11 @@ import { setAIContext } from "@auth0/ai-llamaindex";
 import { withInterruptions } from "@auth0/ai-llamaindex/interrupts";
 import { errorSerializer } from "@auth0/ai-vercel/interrupts";
 
+// Configure OpenAI LLM
+Settings.llm = openai({
+  model: "gpt-4o-mini",
+});
+
 export async function POST(request: Request) {
   const { id, messages }: { id: string; messages: Message[] } =
     await request.json();
@@ -24,10 +30,9 @@ export async function POST(request: Request) {
   return createDataStreamResponse({
     execute: withInterruptions(
       async (dataStream) => {
-        const agent = new OpenAIAgent({
+        const agent = new ReActAgent({
           systemPrompt: "You are an AI assistant",
           tools: [checkUsersCalendar(), listChannels(), listRepositories()],
-          chatHistory: messages as ChatMessage[],
           verbose: true,
         });
 

--- a/examples/calling-apis/chatbot/package.json
+++ b/examples/calling-apis/chatbot/package.json
@@ -25,6 +25,7 @@
     "@auth0/ai-llamaindex": "*",
     "@auth0/ai-vercel": "*",
     "@auth0/nextjs-auth0": "^4.2.1",
+    "@llamaindex/openai": "^0.4.18",
     "@langchain/community": "^0.3.53",
     "@langchain/core": "^0.3.72",
     "@langchain/langgraph": "^0.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -560,124 +560,13 @@
       "dependencies": {
         "@auth0/ai": "*",
         "@auth0/ai-llamaindex": "*",
+        "@llamaindex/openai": "^0.4.18",
         "dotenv": "^16.4.7",
         "enquirer": "^2.4.1",
         "jwt-decode": "^4.0.0",
-        "llamaindex": "^0.9.0",
+        "llamaindex": "^0.11.28",
         "open": "^10.1.0",
         "zod": "^3.24.1"
-      }
-    },
-    "examples/async-user-confirmation/llamaindex/node_modules/@llamaindex/cloud": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@llamaindex/cloud/-/cloud-4.0.3.tgz",
-      "integrity": "sha512-pUHX8Ecs4WAXIoAcegPzuxz05SsufU5+HAdb9H/gowLB1rydQOJjk2CvBuzgQbbablmggvCBpt/tpdEZYOKd2w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29"
-      }
-    },
-    "examples/async-user-confirmation/llamaindex/node_modules/@llamaindex/core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.2.tgz",
-      "integrity": "sha512-e0NH7X1C8yq9sCqj1Ys9jL9rITCXBKfZwmKnTHYxpXorPeuNmlFmuoogahJTwLNsILBDTOVAUexO88SqmAFUrA==",
-      "dependencies": {
-        "@llamaindex/env": "0.1.29",
-        "@types/node": "^22.9.0",
-        "magic-bytes.js": "^1.10.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.3"
-      }
-    },
-    "examples/async-user-confirmation/llamaindex/node_modules/@llamaindex/env": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@llamaindex/env/-/env-0.1.29.tgz",
-      "integrity": "sha512-GoITt+QLDNIhu2i1sGsPH8tHH13Gxp4i4ofMFlefrHagytvF761MG7nvTAQVIqP9kxBYk4dnSQ3lQnVPFAfMZQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "js-tiktoken": "^1.0.12",
-        "pathe": "^1.1.2"
-      },
-      "peerDependencies": {
-        "@huggingface/transformers": "^3.0.2",
-        "gpt-tokenizer": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@huggingface/transformers": {
-          "optional": true
-        },
-        "gpt-tokenizer": {
-          "optional": true
-        }
-      }
-    },
-    "examples/async-user-confirmation/llamaindex/node_modules/@llamaindex/node-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@llamaindex/node-parser/-/node-parser-2.0.2.tgz",
-      "integrity": "sha512-pWqEfFRMW5TFzbDyEDWqhipR9P/HBF2C+pEeTroyRACZtKJLbeg3R3e2g4gmfnPxmxQIXkGn2UFK8Io4nwVNOg==",
-      "dependencies": {
-        "html-to-text": "^9.0.5"
-      },
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "tree-sitter": "^0.22.0",
-        "web-tree-sitter": "^0.24.3"
-      }
-    },
-    "examples/async-user-confirmation/llamaindex/node_modules/@llamaindex/workflow": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@llamaindex/workflow/-/workflow-1.0.3.tgz",
-      "integrity": "sha512-GzYzLfn12BTQiLVwFr9tGl1Sa7PPVErLLQAJMgvfjUK8cv764SpJGqln8iKTxnKF05HcRrmJeE7ZD9Lzpf7UrA==",
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "zod": "^3.23.8"
-      }
-    },
-    "examples/async-user-confirmation/llamaindex/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "examples/async-user-confirmation/llamaindex/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "examples/async-user-confirmation/llamaindex/node_modules/llamaindex": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/llamaindex/-/llamaindex-0.9.19.tgz",
-      "integrity": "sha512-scXljrnzco0ugnh92vgT0ZpL7REIra+OD+vzaKA92oMnNoCaXv3EwfLNIROeOQ7bDo43PeRN/lU9DkliW1Qihg==",
-      "license": "MIT",
-      "dependencies": {
-        "@llamaindex/cloud": "4.0.3",
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "@llamaindex/node-parser": "2.0.2",
-        "@llamaindex/openai": "0.3.2",
-        "@llamaindex/workflow": "1.0.3",
-        "@types/lodash": "^4.17.7",
-        "@types/node": "^22.9.0",
-        "ajv": "^8.17.1",
-        "lodash": "^4.17.21",
-        "magic-bytes.js": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "examples/async-user-confirmation/sample-api": {
@@ -1438,119 +1327,7 @@
         "@auth0/ai-llamaindex": "*",
         "@openfga/sdk": "^0.8.0",
         "dotenv": "^16.5.0",
-        "llamaindex": "^0.9.0"
-      }
-    },
-    "examples/authorization-for-rag/llamaindex/node_modules/@llamaindex/cloud": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@llamaindex/cloud/-/cloud-4.0.3.tgz",
-      "integrity": "sha512-pUHX8Ecs4WAXIoAcegPzuxz05SsufU5+HAdb9H/gowLB1rydQOJjk2CvBuzgQbbablmggvCBpt/tpdEZYOKd2w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29"
-      }
-    },
-    "examples/authorization-for-rag/llamaindex/node_modules/@llamaindex/core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.2.tgz",
-      "integrity": "sha512-e0NH7X1C8yq9sCqj1Ys9jL9rITCXBKfZwmKnTHYxpXorPeuNmlFmuoogahJTwLNsILBDTOVAUexO88SqmAFUrA==",
-      "dependencies": {
-        "@llamaindex/env": "0.1.29",
-        "@types/node": "^22.9.0",
-        "magic-bytes.js": "^1.10.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.3"
-      }
-    },
-    "examples/authorization-for-rag/llamaindex/node_modules/@llamaindex/env": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@llamaindex/env/-/env-0.1.29.tgz",
-      "integrity": "sha512-GoITt+QLDNIhu2i1sGsPH8tHH13Gxp4i4ofMFlefrHagytvF761MG7nvTAQVIqP9kxBYk4dnSQ3lQnVPFAfMZQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "js-tiktoken": "^1.0.12",
-        "pathe": "^1.1.2"
-      },
-      "peerDependencies": {
-        "@huggingface/transformers": "^3.0.2",
-        "gpt-tokenizer": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@huggingface/transformers": {
-          "optional": true
-        },
-        "gpt-tokenizer": {
-          "optional": true
-        }
-      }
-    },
-    "examples/authorization-for-rag/llamaindex/node_modules/@llamaindex/node-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@llamaindex/node-parser/-/node-parser-2.0.2.tgz",
-      "integrity": "sha512-pWqEfFRMW5TFzbDyEDWqhipR9P/HBF2C+pEeTroyRACZtKJLbeg3R3e2g4gmfnPxmxQIXkGn2UFK8Io4nwVNOg==",
-      "dependencies": {
-        "html-to-text": "^9.0.5"
-      },
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "tree-sitter": "^0.22.0",
-        "web-tree-sitter": "^0.24.3"
-      }
-    },
-    "examples/authorization-for-rag/llamaindex/node_modules/@llamaindex/workflow": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@llamaindex/workflow/-/workflow-1.0.3.tgz",
-      "integrity": "sha512-GzYzLfn12BTQiLVwFr9tGl1Sa7PPVErLLQAJMgvfjUK8cv764SpJGqln8iKTxnKF05HcRrmJeE7ZD9Lzpf7UrA==",
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "zod": "^3.23.8"
-      }
-    },
-    "examples/authorization-for-rag/llamaindex/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "examples/authorization-for-rag/llamaindex/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "examples/authorization-for-rag/llamaindex/node_modules/llamaindex": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/llamaindex/-/llamaindex-0.9.19.tgz",
-      "integrity": "sha512-scXljrnzco0ugnh92vgT0ZpL7REIra+OD+vzaKA92oMnNoCaXv3EwfLNIROeOQ7bDo43PeRN/lU9DkliW1Qihg==",
-      "license": "MIT",
-      "dependencies": {
-        "@llamaindex/cloud": "4.0.3",
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "@llamaindex/node-parser": "2.0.2",
-        "@llamaindex/openai": "0.3.2",
-        "@llamaindex/workflow": "1.0.3",
-        "@types/lodash": "^4.17.7",
-        "@types/node": "^22.9.0",
-        "ajv": "^8.17.1",
-        "lodash": "^4.17.21",
-        "magic-bytes.js": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "llamaindex": "^0.11.28"
       }
     },
     "examples/authorization-for-tools/ai-sdk": {
@@ -1730,124 +1507,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@auth0/ai-llamaindex": "*",
+        "@llamaindex/openai": "^0.4.18",
         "@openfga/sdk": "^0.8.0",
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",
         "enquirer": "^2.4.1",
-        "llamaindex": "^0.9.0",
+        "llamaindex": "^0.11.28",
         "zod": "^3.24.1"
-      }
-    },
-    "examples/authorization-for-tools/llamaindex/node_modules/@llamaindex/cloud": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@llamaindex/cloud/-/cloud-4.0.3.tgz",
-      "integrity": "sha512-pUHX8Ecs4WAXIoAcegPzuxz05SsufU5+HAdb9H/gowLB1rydQOJjk2CvBuzgQbbablmggvCBpt/tpdEZYOKd2w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29"
-      }
-    },
-    "examples/authorization-for-tools/llamaindex/node_modules/@llamaindex/core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.2.tgz",
-      "integrity": "sha512-e0NH7X1C8yq9sCqj1Ys9jL9rITCXBKfZwmKnTHYxpXorPeuNmlFmuoogahJTwLNsILBDTOVAUexO88SqmAFUrA==",
-      "dependencies": {
-        "@llamaindex/env": "0.1.29",
-        "@types/node": "^22.9.0",
-        "magic-bytes.js": "^1.10.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.3"
-      }
-    },
-    "examples/authorization-for-tools/llamaindex/node_modules/@llamaindex/env": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@llamaindex/env/-/env-0.1.29.tgz",
-      "integrity": "sha512-GoITt+QLDNIhu2i1sGsPH8tHH13Gxp4i4ofMFlefrHagytvF761MG7nvTAQVIqP9kxBYk4dnSQ3lQnVPFAfMZQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "js-tiktoken": "^1.0.12",
-        "pathe": "^1.1.2"
-      },
-      "peerDependencies": {
-        "@huggingface/transformers": "^3.0.2",
-        "gpt-tokenizer": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@huggingface/transformers": {
-          "optional": true
-        },
-        "gpt-tokenizer": {
-          "optional": true
-        }
-      }
-    },
-    "examples/authorization-for-tools/llamaindex/node_modules/@llamaindex/node-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@llamaindex/node-parser/-/node-parser-2.0.2.tgz",
-      "integrity": "sha512-pWqEfFRMW5TFzbDyEDWqhipR9P/HBF2C+pEeTroyRACZtKJLbeg3R3e2g4gmfnPxmxQIXkGn2UFK8Io4nwVNOg==",
-      "dependencies": {
-        "html-to-text": "^9.0.5"
-      },
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "tree-sitter": "^0.22.0",
-        "web-tree-sitter": "^0.24.3"
-      }
-    },
-    "examples/authorization-for-tools/llamaindex/node_modules/@llamaindex/workflow": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@llamaindex/workflow/-/workflow-1.0.3.tgz",
-      "integrity": "sha512-GzYzLfn12BTQiLVwFr9tGl1Sa7PPVErLLQAJMgvfjUK8cv764SpJGqln8iKTxnKF05HcRrmJeE7ZD9Lzpf7UrA==",
-      "peerDependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "zod": "^3.23.8"
-      }
-    },
-    "examples/authorization-for-tools/llamaindex/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "examples/authorization-for-tools/llamaindex/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "examples/authorization-for-tools/llamaindex/node_modules/llamaindex": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/llamaindex/-/llamaindex-0.9.19.tgz",
-      "integrity": "sha512-scXljrnzco0ugnh92vgT0ZpL7REIra+OD+vzaKA92oMnNoCaXv3EwfLNIROeOQ7bDo43PeRN/lU9DkliW1Qihg==",
-      "license": "MIT",
-      "dependencies": {
-        "@llamaindex/cloud": "4.0.3",
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "@llamaindex/node-parser": "2.0.2",
-        "@llamaindex/openai": "0.3.2",
-        "@llamaindex/workflow": "1.0.3",
-        "@types/lodash": "^4.17.7",
-        "@types/node": "^22.9.0",
-        "ajv": "^8.17.1",
-        "lodash": "^4.17.21",
-        "magic-bytes.js": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "examples/calling-apis/chatbot": {
@@ -1869,6 +1535,7 @@
         "@langchain/langgraph": "^0.4.6",
         "@langchain/langgraph-sdk": "^0.0.109",
         "@langchain/openai": "^0.3.14",
+        "@llamaindex/openai": "^0.4.18",
         "@octokit/rest": "^21.1.1",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
@@ -7703,113 +7370,16 @@
       }
     },
     "node_modules/@llamaindex/openai": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@llamaindex/openai/-/openai-0.3.2.tgz",
-      "integrity": "sha512-FZcvUZ21pKIEde2vfq3kOQSgaS+GKnsN7C1+0/N/I6jHFBo13PsIFl7vLOfX2Felm9dPaWdoG99nt45YZcP8xw==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@llamaindex/openai/-/openai-0.4.18.tgz",
+      "integrity": "sha512-ZPgxf0ICNOAJ8oQ/1NZAq954raT8GWTBGU2c1blggTZVssFqnKbVD9/C2DH5fndSspVdAQfVnc/gS+TAuzsz1w==",
       "dependencies": {
-        "@llamaindex/core": "0.6.2",
-        "@llamaindex/env": "0.1.29",
-        "openai": "^4.90.0"
-      }
-    },
-    "node_modules/@llamaindex/openai/node_modules/@llamaindex/core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@llamaindex/core/-/core-0.6.2.tgz",
-      "integrity": "sha512-e0NH7X1C8yq9sCqj1Ys9jL9rITCXBKfZwmKnTHYxpXorPeuNmlFmuoogahJTwLNsILBDTOVAUexO88SqmAFUrA==",
-      "dependencies": {
-        "@llamaindex/env": "0.1.29",
-        "@types/node": "^22.9.0",
-        "magic-bytes.js": "^1.10.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.3"
-      }
-    },
-    "node_modules/@llamaindex/openai/node_modules/@llamaindex/env": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@llamaindex/env/-/env-0.1.29.tgz",
-      "integrity": "sha512-GoITt+QLDNIhu2i1sGsPH8tHH13Gxp4i4ofMFlefrHagytvF761MG7nvTAQVIqP9kxBYk4dnSQ3lQnVPFAfMZQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "js-tiktoken": "^1.0.12",
-        "pathe": "^1.1.2"
+        "openai": "^5.12.0"
       },
       "peerDependencies": {
-        "@huggingface/transformers": "^3.0.2",
-        "gpt-tokenizer": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@huggingface/transformers": {
-          "optional": true
-        },
-        "gpt-tokenizer": {
-          "optional": true
-        }
+        "@llamaindex/core": "0.6.20",
+        "@llamaindex/env": "0.1.30"
       }
-    },
-    "node_modules/@llamaindex/openai/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@llamaindex/openai/node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@llamaindex/openai/node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.123",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
-      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@llamaindex/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@llamaindex/workflow": {
       "version": "1.1.22",
@@ -33128,8 +32698,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@auth0/ai": "*",
+        "@llamaindex/openai": "^0.4.18",
         "html-to-text": "^9.0.5",
-        "llamaindex": "^0.11",
+        "llamaindex": "^0.11.28",
         "lodash": "^4.17.21",
         "magic-bytes.js": "^1.10.0"
       },

--- a/packages/ai-llamaindex/package.json
+++ b/packages/ai-llamaindex/package.json
@@ -46,8 +46,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@auth0/ai": "*",
+    "@llamaindex/openai": "^0.4.18",
     "html-to-text": "^9.0.5",
-    "llamaindex": "^0.11",
+    "llamaindex": "^0.11.28",
     "lodash": "^4.17.21",
     "magic-bytes.js": "^1.10.0"
   },
@@ -55,8 +56,8 @@
     "@openfga/sdk": "^0.8.0"
   },
   "devDependencies": {
-    "@types/node": "^22.10.6",
     "@eslint/compat": "^1.2.7",
+    "@types/node": "^22.10.6",
     "eslint": "^9.22.0",
     "typedoc": "^0.27.6",
     "typescript": "^5.7.3",


### PR DESCRIPTION
Fixes a breaking change to `llamaindex` w/ `^0.11.28` upgrade in https://github.com/auth0-lab/auth0-ai-js/pull/264.

Previously, our `@auth0/ai-llamaindex` package had been updated to reference llamaindex `^0.11`, however the `examples/` were still referencing `^0.9`.

This addresses the breaking changes to `OpenAIAgent`  w/ that upgrade.


