### PR TITLE
feat: use Authorization token with tools in LangGraph chatbot example

### DIFF
--- a/examples/calling-apis/chatbot/app/(langgraph)/api/langgraph/[..._path]/route.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/api/langgraph/[..._path]/route.ts
@@ -12,19 +12,6 @@ async function getAccessToken() {
   return tokenResult.token;
 }
 
-function addAuthContext(body: any, accessToken: string) {
-  return {
-    ...body,
-    config: {
-      configurable: {
-        _credentials: {
-          accessToken,
-        },
-      },
-    },
-  };
-}
-
 async function makeLangGraphRequest(
   endpoint: string,
   method: string = "GET",
@@ -76,21 +63,11 @@ export async function POST(
     const path = _path || [];
     const endpoint = path.length > 0 ? `/${path.join("/")}` : "/";
 
-    let requestBody = body;
-
-    if (endpoint.includes("/runs")) {
-      requestBody = addAuthContext(body, accessToken);
-    } else if (endpoint.includes("/threads")) {
-      requestBody = body;
-    } else {
-      requestBody = addAuthContext(body, accessToken);
-    }
-
     const response = await makeLangGraphRequest(
       endpoint,
       "POST",
       accessToken,
-      requestBody
+      body
     );
 
     if (endpoint.includes("/stream")) {

--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/auth.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/auth.ts
@@ -72,6 +72,10 @@ auth.authenticate(async (request: Request) => {
           permissions:
             typeof payload.scope === "string" ? payload.scope.split(" ") : [],
           auth_type: "auth0",
+          // include the access token for use with Auth0 Token Vault exchanges by tools
+          _credentials: {
+            accessToken: token,
+          },
           // Add any other claims you need
           ...payload,
         };

--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/auth0-ai.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/auth0-ai.ts
@@ -14,7 +14,8 @@ const withAccessTokenForConnection = (connection: string, scopes: string[]) =>
     connection,
     scopes,
     accessToken: async (_, config) => {
-      return config.configurable._credentials.accessToken;
+      return config.configurable?.langgraph_auth_user?._credentials
+        ?.accessToken;
     },
     subjectTokenType: SUBJECT_TOKEN_TYPES.SUBJECT_TYPE_ACCESS_TOKEN,
   });


### PR DESCRIPTION
Small change to the `examples/calling-apis/chatbot` LangGraph example to reference the `Authorization` header / access token rather than from `req.body` after authorization has occurred.