### PR TITLE
CIBA Fixes: requested_expiry param and Retry-After header handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10109,7 +10109,9 @@
       "license": "MIT"
     },
     "node_modules/auth0": {
-      "version": "4.29.0",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-4.30.0.tgz",
+      "integrity": "sha512-mDV0ojKKfNGwG/Sm06RUhHrkrA5A/dLyK7dAyZDuBMF+7n27OzyZycArmLx/aQpXXD3W+W2Vu8BcDtwBXqmi7Q==",
       "license": "MIT",
       "dependencies": {
         "jose": "^4.13.2",
@@ -25602,7 +25604,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@openfga/sdk": "^0.8.0",
-        "auth0": "^4.18.0",
+        "auth0": "^4.30.0",
         "jose": "^5.9.6",
         "openid-client": "^6.1.7",
         "stable-hash": "^0.0.5",
@@ -25764,7 +25766,6 @@
         "@ai-sdk/react": "^2.0.0",
         "@auth0/ai": "*",
         "ai": "^5.0.0",
-        "auth0": "^4.18.0",
         "stable-hash": "^0.0.5",
         "zod-to-json-schema": "^3.24.5"
       },

--- a/packages/ai-vercel/package.json
+++ b/packages/ai-vercel/package.json
@@ -53,7 +53,6 @@
     "@ai-sdk/react": "^2.0.0",
     "@auth0/ai": "*",
     "ai": "^5.0.0",
-    "auth0": "^4.18.0",
     "stable-hash": "^0.0.5",
     "zod-to-json-schema": "^3.24.5"
   },

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint \"./**/*.ts*\"",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
+    "test:debug": "vitest --inspect-brk --no-file-parallelism run",
     "semantic-release": "npx --no semantic-release"
   },
   "author": {
@@ -79,7 +80,7 @@
   },
   "dependencies": {
     "@openfga/sdk": "^0.8.0",
-    "auth0": "^4.18.0",
+    "auth0": "^4.30.0",
     "jose": "^5.9.6",
     "openid-client": "^6.1.7",
     "stable-hash": "^0.0.5",

--- a/packages/ai/src/authorizers/ciba/CIBAAuthorizerBase.ts
+++ b/packages/ai/src/authorizers/ciba/CIBAAuthorizerBase.ts
@@ -151,7 +151,8 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
       if (e.error === "slow_down") {
         throw new AuthorizationPollingInterrupt(
           e.error_description,
-          authRequest
+          authRequest,
+          Number(e.headers.get('retry-after'))
         );
       }
 
@@ -190,7 +191,7 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
           err instanceof AuthorizationPendingInterrupt ||
           err instanceof AuthorizationPollingInterrupt
         ) {
-          await sleep(err.request.interval * 1000);
+          await sleep(err.nextRetryInterval() * 1000);
         } else {
           throw err;
         }

--- a/packages/ai/src/authorizers/ciba/CIBAAuthorizerBase.ts
+++ b/packages/ai/src/authorizers/ciba/CIBAAuthorizerBase.ts
@@ -97,7 +97,7 @@ export class CIBAAuthorizerBase<ToolExecuteArgs extends any[]> {
     const authParams: Record<string, any> = {
       scope: ensureOpenIdScope(this.params.scopes).join(" "),
       audience: this.params.audience || "",
-      request_expiry: (this.params.requestExpiry ?? 300).toString(),
+      requested_expiry: (this.params.requestedExpiry ?? 300).toString(),
       binding_message:
         (await resolveParameter(this.params.bindingMessage, toolContext)) ?? "",
       userId: (await resolveParameter(this.params.userID, toolContext)) ?? "",

--- a/packages/ai/src/authorizers/ciba/CIBAAuthorizerParams.ts
+++ b/packages/ai/src/authorizers/ciba/CIBAAuthorizerParams.ts
@@ -42,9 +42,9 @@ export type CIBAAuthorizerParams<ToolExecuteArgs extends any[]> = {
   /**
    * The time in seconds for the authorization request to expire.
    *
-   * Defaults to 5m.
+   * Defaults to 300 (5 minutes).
    */
-  requestExpiry?: number;
+  requestedExpiry?: number;
 
   /**
    * The behavior when the authorization request is made.

--- a/packages/ai/src/interrupts/CIBAInterrupts.ts
+++ b/packages/ai/src/interrupts/CIBAInterrupts.ts
@@ -89,6 +89,13 @@ export class AuthorizationPendingInterrupt
   ) {
     super(message, AuthorizationPendingInterrupt.code);
   }
+
+  /**
+   * Returns the interval in seconds to wait until the next polling attempt.
+   */
+  public nextRetryInterval(): number {
+    return this.request.interval;
+  }
 }
 
 /**
@@ -101,9 +108,17 @@ export class AuthorizationPollingInterrupt
   public static code: string = "CIBA_AUTHORIZATION_POLLING_ERROR" as const;
   constructor(
     message: string,
-    public readonly request: CIBAAuthorizationRequest
+    public readonly request: CIBAAuthorizationRequest,
+    public readonly retryAfter: number
   ) {
     super(message, AuthorizationPollingInterrupt.code);
+  }
+
+  /**
+   * Returns the interval in seconds to wait until the next polling attempt.
+   */
+  public nextRetryInterval(): number {
+    return this.retryAfter || this.request.interval;
   }
 }
 
@@ -119,6 +134,6 @@ export class InvalidGrantInterrupt
     message: string,
     public readonly request: CIBAAuthorizationRequest
   ) {
-    super(message, AuthorizationPollingInterrupt.code);
+    super(message, InvalidGrantInterrupt.code);
   }
 }

--- a/packages/ai/test/ciba/ciba-authorizer.test.ts
+++ b/packages/ai/test/ciba/ciba-authorizer.test.ts
@@ -18,6 +18,7 @@ describe("CIBAAuthorizerBase", () => {
     userID: "user123",
     bindingMessage: "test-binding",
     scopes: ["read:users"],
+    requestedExpiry: 360,
     store: {
       get: vi.fn(),
       put: vi.fn(),
@@ -110,6 +111,16 @@ describe("CIBAAuthorizerBase", () => {
 
     it("should start the backchannel authorization", async () => {
       expect(mockAuth0.backchannel.authorize).toHaveBeenCalled();
+    });
+
+    it("should have passed the right arguments", async () => {
+      expect(mockAuth0.backchannel.authorize).toHaveBeenCalledWith({
+        audience: "",
+        binding_message: "test-binding",
+        requested_expiry: "360",
+        scope: "openid read:users",
+        userId: "user123",
+      });
     });
 
     it("should store the authorization response", async () => {


### PR DESCRIPTION
* For the CIBA Authorizer, renamed `requestExpiry` to `requestedExpiry` and ensured that we send `requested_expiry` to the back-end. This is a breaking change! ⚠️ 
* For the CIBA Authorizer, added handling of the `Retry-After` HTTP response header to determine the next retry interval in the case of error response `slow_down`. The `Retry-After` HTTP header contains an integer value, that is meant to be used as the period of time to wait before polling the endpoint again. So the handling logic will use that value instead of the `interval` value returned previously by the server (just for one time).

ref. https://auth0team.atlassian.net/browse/AIDX-128