### PR TITLE
feat: with langgraph-nextjs-api-passthrough

### DIFF
--- a/examples/calling-apis/chatbot/app/(langgraph)/lib/auth.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/lib/auth.ts
@@ -22,8 +22,8 @@ const auth = new Auth();
 
 // Register the authentication handler
 auth.authenticate(async (request: Request) => {
-  const authHeader = request.headers.get("Authorization");
-  const xApiKeyHeader = request.headers.get("x-api-key");
+  const authHeader = request.headers.get("Authorization") || undefined;
+  const xApiKeyHeader = request.headers.get("x-api-key") || undefined;
   try {
     /**
      * LangGraph Platform will convert the `Authorization` header from the client to an `x-api-key` header automatically

--- a/examples/calling-apis/chatbot/package.json
+++ b/examples/calling-apis/chatbot/package.json
@@ -54,6 +54,7 @@
     "genkitx-openai": "^0.20.2",
     "googleapis": "^150.0.1",
     "jose": "^5.9.6",
+    "langgraph-nextjs-api-passthrough": "^0.1.4",
     "lucide-react": "^0.479.0",
     "next": "^15.2.3",
     "nuqs": "^2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -414,6 +414,7 @@
         "genkitx-openai": "^0.20.2",
         "googleapis": "^150.0.1",
         "jose": "^5.9.6",
+        "langgraph-nextjs-api-passthrough": "^0.1.4",
         "lucide-react": "^0.479.0",
         "next": "^15.2.3",
         "nuqs": "^2.4.1",
@@ -16002,6 +16003,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/langgraph-nextjs-api-passthrough": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/langgraph-nextjs-api-passthrough/-/langgraph-nextjs-api-passthrough-0.1.4.tgz",
+      "integrity": "sha512-qGjHs8AnyP5XxxparmqkW4H6fHLjAgveCQnKzpBg0QhgyCc5wbGXmjCsh6eMgZ0meT+WS2oy31kNlt7OwPqSig==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "*"
       }
     },
     "node_modules/langsmith": {


### PR DESCRIPTION
Would reinstitute passthrough for our custom auth handler w/ Next.js. 

Per discussion, this library should continue to be supported for the time being, and can be referenced from here.