### PR TITLE
fix: update nextjs-api-passthrough options, headers

### DIFF
--- a/examples/calling-apis/chatbot/app/(langgraph)/api/langgraph/[..._path]/route.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/api/langgraph/[..._path]/route.ts
@@ -15,15 +15,18 @@ async function getAccessToken() {
 
 export const { GET, POST, PUT, PATCH, DELETE, OPTIONS, runtime } =
   initApiPassthrough({
+    disableWarningLog: true,
     apiUrl: process.env.LANGGRAPH_API_URL,
     apiKey: process.env.LANGSMITH_API_KEY,
     runtime: "edge",
     baseRoute: "langgraph/",
     headers: async (req: NextRequest) => {
-      const headers: Record<string, string> = {};
-      req.headers.forEach((value, key) => {
-        headers[key] = value;
-      });
+      const headers: Record<string, string> = {
+        ...Object.fromEntries(req.headers.entries()),
+      };
+
+      // Remove Next.js session cookie header
+      delete headers.Cookie;
 
       const accessToken = await getAccessToken();
       headers["Authorization"] = `Bearer ${accessToken}`;

--- a/examples/calling-apis/chatbot/app/(langgraph)/api/langgraph/[..._path]/route.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/api/langgraph/[..._path]/route.ts
@@ -21,12 +21,28 @@ export const { GET, POST, PUT, PATCH, DELETE, OPTIONS, runtime } =
     runtime: "edge",
     baseRoute: "langgraph/",
     headers: async (req: NextRequest) => {
-      const headers: Record<string, string> = {
-        ...Object.fromEntries(req.headers.entries()),
-      };
+      const headers: Record<string, string> = {};
 
-      // Remove Next.js session cookie header
-      delete headers.Cookie;
+      // Only pass through essential headers for the LangGraph API
+      const allowedHeaders = [
+        "content-type",
+        "content-length",
+        "accept",
+        "accept-encoding",
+        "user-agent",
+        "origin",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-port",
+        "x-forwarded-proto",
+      ];
+
+      allowedHeaders.forEach((headerName) => {
+        const value = req.headers.get(headerName);
+        if (value) {
+          headers[headerName] = value;
+        }
+      });
 
       const accessToken = await getAccessToken();
       headers["Authorization"] = `Bearer ${accessToken}`;

--- a/examples/calling-apis/chatbot/app/(langgraph)/api/langgraph/[..._path]/route.ts
+++ b/examples/calling-apis/chatbot/app/(langgraph)/api/langgraph/[..._path]/route.ts
@@ -1,5 +1,4 @@
 import { initApiPassthrough } from "langgraph-nextjs-api-passthrough";
-import { NextRequest } from "next/server";
 
 import { auth0 } from "@/lib/auth0";
 
@@ -15,37 +14,14 @@ async function getAccessToken() {
 
 export const { GET, POST, PUT, PATCH, DELETE, OPTIONS, runtime } =
   initApiPassthrough({
-    disableWarningLog: true,
     apiUrl: process.env.LANGGRAPH_API_URL,
     apiKey: process.env.LANGSMITH_API_KEY,
     runtime: "edge",
     baseRoute: "langgraph/",
-    headers: async (req: NextRequest) => {
-      const headers: Record<string, string> = {};
-
-      // Only pass through essential headers for the LangGraph API
-      const allowedHeaders = [
-        "content-type",
-        "content-length",
-        "accept",
-        "accept-encoding",
-        "user-agent",
-        "origin",
-        "x-forwarded-for",
-        "x-forwarded-host",
-        "x-forwarded-port",
-        "x-forwarded-proto",
-      ];
-
-      allowedHeaders.forEach((headerName) => {
-        const value = req.headers.get(headerName);
-        if (value) {
-          headers[headerName] = value;
-        }
-      });
-
+    headers: async () => {
       const accessToken = await getAccessToken();
-      headers["Authorization"] = `Bearer ${accessToken}`;
-      return headers;
+      return {
+        Authorization: `Bearer ${accessToken}`,
+      };
     },
   });


### PR DESCRIPTION
Another small change to the passthrough options after reviewing example again today w/ @PavelKorobchuk :

- add `disableWarningLog` to ignore the warning logs about using custom auth approach (we are actually already doing that now, and just opting to still use the passthrough for convenience)
- remove session cookie from forwarded request (it is only needed by the Next.js App Server) and passing this cookie will also sometimes lead to `431 "Request Header Fields Too Large"` error
