### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Dependencies
         id: npm-ci
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Validate Commits Messages
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This would avoid malicious scripts in vulnerable packages to be executed on CI