### PR TITLE
fix: add repository url to package.json for npm provenance validation

### DIFF
--- a/packages/ai-cloudflare/package.json
+++ b/packages/ai-cloudflare/package.json
@@ -2,6 +2,10 @@
   "name": "@auth0/ai-cloudflare",
   "version": "0.0.0",
   "description": "Auth0 AI tools for the Agents SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/auth0-ai-js"
+  },
   "types": "dist/esm/index.d.ts",
   "module": "./dist/esm/index.js",
   "scripts": {

--- a/packages/ai-components/package.json
+++ b/packages/ai-components/package.json
@@ -2,6 +2,10 @@
   "name": "@auth0/ai-components",
   "version": "0.0.0",
   "description": "Auth0 AI Components",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/auth0-ai-js"
+  },
   "bin": "./bin/cli.js",
   "files": [
     "dist/**/*.{*js,*js.map,d.ts}",

--- a/packages/ai-genkit/package.json
+++ b/packages/ai-genkit/package.json
@@ -2,6 +2,10 @@
   "name": "@auth0/ai-genkit",
   "version": "0.0.0",
   "description": "Auth0 AI for GenKit",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/auth0-ai-js"
+  },
   "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/ai-langchain/package.json
+++ b/packages/ai-langchain/package.json
@@ -2,6 +2,10 @@
   "name": "@auth0/ai-langchain",
   "version": "0.0.0",
   "description": "Auth0 AI for LangChain",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/auth0-ai-js"
+  },
   "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/ai-llamaindex/package.json
+++ b/packages/ai-llamaindex/package.json
@@ -2,6 +2,10 @@
   "name": "@auth0/ai-llamaindex",
   "version": "0.0.0",
   "description": "Auth0 AI for LlamaIndex",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/auth0-ai-js"
+  },
   "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/ai-redis/package.json
+++ b/packages/ai-redis/package.json
@@ -2,6 +2,10 @@
   "name": "@auth0/ai-redis",
   "version": "0.0.0",
   "description": "Auth0 AI ioredis Data Store implementation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/auth0-ai-js"
+  },
   "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/ai-vercel/package.json
+++ b/packages/ai-vercel/package.json
@@ -2,6 +2,10 @@
   "name": "@auth0/ai-vercel",
   "version": "0.0.0",
   "description": "Auth0 AI for AI SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/auth0-ai-js"
+  },
   "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -2,6 +2,10 @@
   "name": "@auth0/ai",
   "version": "0.0.0",
   "description": "Auth0AI SDK for JavaScript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/auth0-ai-js"
+  },
   "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
### Description
npm trusted publishing requires the repository.url field in package.json to match the GitHub repository URL from the sigstore provenance bundle. Without it, npm publish fails with E422 during provenance verification: https://github.com/auth0/auth0-ai-js/actions/runs/24738420019/job/72371367868#logs

  - Add repository type and url to `packages/ai/package.json`
  - Add repository type and url to `packages/ai-cloudflare/package.json`
  - Add repository type and url to `packages/ai-components/package.json`
  - Add repository type and url to `packages/ai-genkit/package.json`
  - Add repository type and url to `packages/ai-langchain/package.json`
  - Add repository type and url to `packages/ai-llamaindex/package.json`
  - Add repository type and url to `packages/ai-redis/package.json`
  - Add repository type and url to `packages/ai-vercel/package.json`


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
